### PR TITLE
feat: support multi-reference image generation and fix selfie/tool reference handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -132,6 +132,14 @@ class OmniDrawPlugin(Star):
                         
         return processed_paths
 
+    def _normalize_count(self, count: Any) -> int:
+        try:
+            if isinstance(count, str):
+                count = count.strip()
+            return int(count)
+        except (TypeError, ValueError):
+            return 1
+
     def _has_permission(self, event: AstrMessageEvent) -> bool:
         allowed = self.plugin_config.allowed_users
         if not allowed: return True
@@ -229,7 +237,7 @@ class OmniDrawPlugin(Star):
         try:
             async with aiohttp.ClientSession() as session:
                 chain_manager = ChainManager(self.plugin_config, session)
-                image_url = await chain_manager.run_chain("text2img", preset_prompt, user_ref=safe_refs[0])
+                image_url = await chain_manager.run_chain("text2img", preset_prompt, user_refs=safe_refs)
                 
             yield event.chain_result([self._create_image_component(image_url)])
         except Exception as e:
@@ -250,7 +258,7 @@ class OmniDrawPlugin(Star):
         raw_refs = self._get_event_images(event)
         
         if not message and not raw_refs:
-            yield event.plain_result(f"{MessageEmoji.WARNING} 请输入提示词或附带一张参考图！")
+            yield event.plain_result(f"{MessageEmoji.WARNING} 请输入提示词或附带参考图！")
             return
             
         safe_refs = await self._process_and_save_images(raw_refs)
@@ -258,8 +266,8 @@ class OmniDrawPlugin(Star):
         
         actual_ref_count = 0
         if safe_refs:
-            kwargs["user_ref"] = safe_refs[0]
-            actual_ref_count = 1
+            kwargs["user_refs"] = safe_refs
+            actual_ref_count = len(safe_refs)
             
         yield event.plain_result(
             f"{MessageEmoji.PAINTING} 收到灵感，正在绘制...\n"
@@ -285,17 +293,19 @@ class OmniDrawPlugin(Star):
         optimized_action = opt_actions[0] if opt_actions else user_input
         
         final_prompt, extra_kwargs = self.persona_manager.build_persona_prompt(optimized_action)
-        persona_ref = extra_kwargs.get("user_ref", "")
+        persona_ref = extra_kwargs.get("persona_ref", "")
         raw_refs = self._get_event_images(event)
         target_refs = raw_refs if raw_refs else ([persona_ref] if persona_ref else [])
         
         safe_refs = await self._process_and_save_images(target_refs)
         actual_ref_count = 0
         if safe_refs:
-            extra_kwargs["user_ref"] = safe_refs[0]
-            actual_ref_count = 1
+            extra_kwargs["user_refs"] = safe_refs
+            actual_ref_count = len(safe_refs) + (1 if raw_refs and persona_ref else 0)
+            if not raw_refs:
+                extra_kwargs.pop("persona_ref", None)
         else:
-            extra_kwargs.pop("user_ref", None) 
+            extra_kwargs.pop("user_refs", None)
             
         yield event.plain_result(
             f"{MessageEmoji.INFO} 正在为「{self.plugin_config.persona_name}」生成自拍...\n"
@@ -350,7 +360,7 @@ class OmniDrawPlugin(Star):
         if not self._has_permission(event): return "系统提示：无权限调用。"
 
         try:
-            count = max(1, count)
+            count = max(1, self._normalize_count(count))
             if self.plugin_config.max_batch_count > 0:
                 count = min(count, self.plugin_config.max_batch_count)
             
@@ -368,7 +378,10 @@ class OmniDrawPlugin(Star):
             async with aiohttp.ClientSession() as session:
                 for opt_action in optimized_actions:
                     final_prompt, extra_kwargs = self.persona_manager.build_persona_prompt(opt_action)
-                    if safe_refs: extra_kwargs["user_ref"] = safe_refs[0]
+                    if safe_refs:
+                        extra_kwargs["user_refs"] = safe_refs
+                        if not raw_refs:
+                            extra_kwargs.pop("persona_ref", None)
                     chain_manager = ChainManager(self.plugin_config, session)
                     tasks.append(chain_manager.run_chain(chain_to_use, final_prompt, **extra_kwargs))
                 
@@ -400,7 +413,7 @@ class OmniDrawPlugin(Star):
         if not self._has_permission(event): return "系统提示：无权限调用。"
 
         try:
-            count = max(1, count)
+            count = max(1, self._normalize_count(count))
             if self.plugin_config.max_batch_count > 0:
                 count = min(count, self.plugin_config.max_batch_count)
                 
@@ -409,7 +422,7 @@ class OmniDrawPlugin(Star):
             optimized_actions = await self.prompt_optimizer.optimize(prompt, count)
             raw_refs = self._get_event_images(event)
             safe_refs = await self._process_and_save_images(raw_refs)
-            kwargs = {"user_ref": safe_refs[0]} if safe_refs else {}
+            kwargs = {"user_refs": safe_refs} if safe_refs else {}
 
             tasks = []
             async with aiohttp.ClientSession() as session:
@@ -444,7 +457,7 @@ class OmniDrawPlugin(Star):
         if not self._has_permission(event): return "系统提示：无权限调用。"
 
         try:
-            count = max(1, count)
+            count = max(1, self._normalize_count(count))
             if self.plugin_config.max_batch_count > 0: count = min(count, self.plugin_config.max_batch_count)
             raw_refs = self._get_event_images(event)
             safe_refs = await self._process_and_save_images(raw_refs)

--- a/providers/base.py
+++ b/providers/base.py
@@ -5,7 +5,7 @@ import aiohttp
 import base64
 import os
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List
 from astrbot.api import logger
 from ..models import ProviderConfig
 
@@ -41,6 +41,21 @@ class BaseProvider(ABC):
         except Exception as e:
             logger.error(f"❌ 读取本地图片失败: {e}")
             return None
+
+    def get_reference_images(self, **kwargs: Any) -> List[str]:
+        refs: List[str] = []
+        for key in ("user_refs", "persona_refs"):
+            value = kwargs.get(key)
+            if isinstance(value, (list, tuple)):
+                refs.extend(str(item) for item in value if item)
+
+        for key in ("user_ref", "persona_ref"):
+            value = kwargs.get(key)
+            if value:
+                refs.append(str(value))
+
+        seen = set()
+        return [ref for ref in refs if not (ref in seen or seen.add(ref))]
 
     @abstractmethod
     async def generate_image(self, prompt: str, **kwargs: Any) -> str:

--- a/providers/openai_chat_impl.py
+++ b/providers/openai_chat_impl.py
@@ -39,11 +39,7 @@ class OpenAIChatProvider(BaseProvider):
         if not current_key:
             raise ValueError("节点未配置 API Key！")
 
-        persona_ref = kwargs.get("persona_ref")
-        user_ref = kwargs.get("user_ref")
-        
-        # 优先取用户的动作图，没有则取人设图
-        target_ref = user_ref or persona_ref
+        target_refs = self.get_reference_images(**kwargs)
 
         # ==========================================
         # 🚀 学习 Gitee AI 的标准 Vision 协议构造法
@@ -52,22 +48,27 @@ class OpenAIChatProvider(BaseProvider):
 
         # 1. ⚠️ 关键修正：图片必须在文字之前！
         # 绝大多数大模型是顺序读取 Token 的，必须让它先“看”到图，再“听”你的要求
-        if target_ref:
-            b64_image = await self._encode_image_to_base64(target_ref)
-            if b64_image:
-                user_content.append({
-                    "type": "image_url",
-                    "image_url": {
-                        "url": b64_image
-                    }
-                })
-                logger.info("✅ [Chat/Vision通道] 成功将参考图封装为视觉信号 (Image First)")
+        image_count = 0
+        for ref_image in target_refs:
+            b64_image = await self._encode_image_to_base64(ref_image)
+            if not b64_image:
+                continue
+            user_content.append({
+                "type": "image_url",
+                "image_url": {
+                    "url": b64_image
+                }
+            })
+            image_count += 1
+
+        if image_count:
+            logger.info(f"✅ [Chat/Vision通道] 成功将 {image_count} 张参考图封装为视觉信号 (Image First)")
 
         # 2. 注入提示词
         # ⚠️ 关键修正：抛弃 System 角色，将系统指令合并到 User 里，确保多模态网关不拦截
         full_prompt = (
             "You are a professional image generation assistant. "
-            "Based on the prompt and the reference image provided above, generate the corresponding image. "
+            "Based on the prompt and the reference image or images provided above, generate the corresponding image. "
             "Return ONLY the markdown image link: ![image](url). DO NOT output any extra conversational text.\n\n"
             f"Prompt: {prompt}"
         )

--- a/providers/openai_impl.py
+++ b/providers/openai_impl.py
@@ -34,26 +34,25 @@ class OpenAIProvider(BaseProvider):
             raise ValueError("节点未配置 API Key！")
 
         base_url = self.config.base_url.rstrip("/")
-        # 标准通道只支持一张图，优先取用户的动作图，没有动作图再去取人设图
-        ref_image = kwargs.get("user_ref") or kwargs.get("persona_ref")
+        ref_images = self.get_reference_images(**kwargs)
 
         # ==========================================
         # 📝 核心：打印最终发送给 API 的原味提示词
         # ==========================================
         logger.info(f"📝 [标准通道] 最终发送给 API 的提示词:\n{prompt}")
 
-        if ref_image:
-            # 🖼️ 图生图模式 (Image-to-Image / Edits)
+        if ref_images:
             url = base_url + "/images/edits"
-            logger.info("✅ 检测到参考图，正切换至标准改图通道: " + url)
-            
-            try:
-                image_bytes = await self._get_image_bytes(ref_image)
-            except Exception as e:
-                raise RuntimeError("读取参考图数据失败: " + str(e))
+            logger.info(f"✅ 检测到 {len(ref_images)} 张参考图，正切换至标准改图通道: {url}")
 
             data = aiohttp.FormData()
-            data.add_field('image', image_bytes, filename='reference.png', content_type='image/png')
+            for idx, ref_image in enumerate(ref_images, start=1):
+                try:
+                    image_bytes = await self._get_image_bytes(ref_image)
+                except Exception as e:
+                    raise RuntimeError(f"读取第 {idx} 张参考图数据失败: {e}")
+                data.add_field('image', image_bytes, filename=f'reference_{idx}.png', content_type='image/png')
+
             data.add_field('prompt', prompt)
             data.add_field('model', self.config.model)
             data.add_field('n', '1')


### PR DESCRIPTION
## 背景

本次 PR 为图片生成链路补充了多参考图支持，并修复了自拍模式与 LLM 工具调用中若干与参考图相关的问题。

此前，插件虽然能够从消息中提取多张图片，但在实际调用图片生成 provider 时，通常只会消费单张参考图。因此即使用户同时提供了多张参考图，`/画`、`/自拍` 以及基于 LLM 工具的生图流程也无法完整利用这些输入。

本次修改将图片生成能力补齐到与视频生成一致的多参考图水平，同时修复了测试过程中发现的参考图计数与参数兼容性问题。

## 变更内容

- 为图片生成增加多参考图支持
  - `/画` 现在会将可用参考图完整传递到图片生成链路
  - `generate_image` LLM 工具现在支持从事件上下文中读取多张参考图
  - `openai` 标准图片通道现在会在改图请求中提交多个 `image` 字段
  - `openai_chat` 视觉通道现在会在多模态请求中注入多个 `image_url` 块

- 统一 provider 侧参考图处理逻辑
  - 在 provider 基类中增加共享的参考图收集逻辑
  - 在支持新多图参数的同时，兼容旧的单图参数写法

- 修复 LLM 工具 `count` 参数兼容问题
  - 当框架将 `count` 以字符串形式传入时，先安全归一化再参与计算
  - 修复范围包括 `generate_image`、`generate_selfie` 和 `generate_video`

- 修复 `/自拍` 参考图数量显示不准确的问题
  - 当人设参考图与用户额外上传图片同时存在时，修正 `/自拍` 的参考图显示数量
  - 保证用户看到的数量与实际提交给 provider 的参考图数量一致

## 测试情况

本地已验证以下场景：

- `/画` 无参考图
- `/画` 单参考图
- `/画` 多参考图
- `generate_image` LLM 工具读取事件携带参考图
- `/自拍` 仅使用人设参考图
- `/自拍` 同时使用人设参考图与用户额外上传图片
- LLM 工具在 `count` 为字符串时的兼容处理
- Python 语法编译校验通过

## 备注

- 本次 PR 的主体属于功能增强，因为它为图片生成新增了真实可用的多参考图能力，而不只是修复一个已有错误。
- 同时也包含了少量与新链路接入相关的兼容性修复。
- 视频生成相关逻辑本次未做变更。