### PR TITLE
fix: 修复 /画、/自拍、/视频 长提示词及尾部 -- 参数被截断的问题，并优化调试输出格式

### DIFF
--- a/main.py
+++ b/main.py
@@ -344,7 +344,7 @@ class OmniDrawPlugin(Star):
         
         msg = f"{MessageEmoji.PAINTING} 收到灵感，正在绘制..."
         if self.plugin_config.verbose_report:
-            msg += f"\n[调试] 宏对应提示词: {preset_prompt}\n[调试] 识别参考图: {len(safe_refs) if safe_refs else 0}张"
+            msg += f"\n📝 宏对应提示词: {preset_prompt}\n🖼️ 实际参考图：{len(safe_refs) if safe_refs else 0} 张"
         yield event.plain_result(msg)
         
         try:
@@ -368,11 +368,12 @@ class OmniDrawPlugin(Star):
             
         safe_refs = await self._process_and_save_images(raw_refs)
         prompt, kwargs = self.cmd_parser.parse(message)
+        param_count = len(kwargs)
         if safe_refs: kwargs["user_refs"] = safe_refs
             
         msg = f"{MessageEmoji.PAINTING} 收到灵感，正在绘制..."
         if self.plugin_config.verbose_report:
-            msg += f"\n[调试] 最终提示词: {prompt}\n[调试] 透传参数: {len(kwargs)}个\n[调试] 识别参考图: {len(safe_refs) if safe_refs else 0}张"
+            msg += f"\n📝 最终提示词: {prompt}\n⚙️ 附加参数：{param_count} 个\n🖼️ 实际参考图：{len(safe_refs) if safe_refs else 0} 张"
         yield event.plain_result(msg)
         
         async with aiohttp.ClientSession() as session:
@@ -392,6 +393,7 @@ class OmniDrawPlugin(Star):
         opt_actions = await self.prompt_optimizer.optimize(user_input, count=1)
         final_prompt, extra_kwargs = self.persona_manager.build_persona_prompt(opt_actions[0] if opt_actions else user_input)
         extra_kwargs.update(kwargs)
+        param_count = len(kwargs)
         
         # 🔴 调用本脚本专用列表字段，底层依然可以拿单数爽
         persona_ref = self.plugin_config.persona_ref_images
@@ -406,7 +408,7 @@ class OmniDrawPlugin(Star):
             
         msg = f"{MessageEmoji.INFO} 正在为「{self.plugin_config.persona_name}」生成自拍，请稍候..."
         if self.plugin_config.verbose_report:
-            msg += f"\n[调试] 构建提示词: {final_prompt}\n[调试] 透传参数: {len(extra_kwargs)}个\n[调试] 识别参考图: {len(safe_refs) if safe_refs else 0}张"
+            msg += f"\n📝 构建提示词: {final_prompt}\n⚙️ 附加参数：{param_count} 个\n🖼️ 实际参考图：{len(safe_refs) if safe_refs else 0} 张"
         yield event.plain_result(msg)
         
         chain_to_use = "selfie" if "selfie" in self.plugin_config.chains else "text2img"
@@ -428,7 +430,7 @@ class OmniDrawPlugin(Star):
         
         msg = f"{MessageEmoji.INFO} 视频任务已提交后台渲染..."
         if self.plugin_config.verbose_report:
-            msg += f"\n[调试] 渲染提示词: {prompt}\n[调试] 识别首尾帧/参考图: {len(safe_refs) if safe_refs else 0}张"
+            msg += f"\n📝 渲染提示词: {prompt}\n⚙️ 附加参数：0 个\n🖼️ 参考图/首尾帧：{len(safe_refs) if safe_refs else 0} 张"
         yield event.plain_result(msg)
         
         asyncio.create_task(self.video_manager.background_task_runner(event, prompt, safe_refs))

--- a/main.py
+++ b/main.py
@@ -185,6 +185,26 @@ class OmniDrawPlugin(Star):
         if sender_id in allowed: return True
         return False
 
+    def _get_event_text(self, event: AstrMessageEvent) -> str:
+        text = getattr(event, "message_str", "") or getattr(event.message_obj, "message_str", "")
+        if text:
+            return str(text).strip()
+        message = getattr(event.message_obj, "message", []) or []
+        plain_text = "".join(getattr(comp, "text", "") for comp in message if isinstance(comp, Plain)).strip()
+        if plain_text:
+            return plain_text
+        return str(getattr(event, "message_obj", "") or "").strip()
+
+    def _extract_command_message(self, event: AstrMessageEvent, command: str, fallback: str = "") -> str:
+        text = self._get_event_text(event)
+        if not text:
+            return fallback.strip()
+        pattern = rf'^\s*[/!！.]?{re.escape(command)}(?:\s+(.*))?$'
+        match = re.match(pattern, text, flags=re.S)
+        if match:
+            return (match.group(1) or "").strip()
+        return fallback.strip()
+
     def _create_image_component(self, image_url: str) -> Image:
         if image_url.startswith("data:image"):
             b64_data = image_url.split(",", 1)[1]
@@ -339,7 +359,8 @@ class OmniDrawPlugin(Star):
     @handle_errors
     async def cmd_draw(self, event: AstrMessageEvent, p1: str="", p2: str="", p3: str="", p4: str="", p5: str="", p6: str="", p7: str="", p8: str="", p9: str="", p10: str="") -> AsyncGenerator[Any, None]:
         if not self._has_permission(event): return
-        message = " ".join(str(x) for x in [p1,p2,p3,p4,p5,p6,p7,p8,p9,p10] if x).strip()
+        fallback = " ".join(str(x) for x in [p1,p2,p3,p4,p5,p6,p7,p8,p9,p10] if x).strip()
+        message = self._extract_command_message(event, "画", fallback)
         raw_refs = self._get_event_images(event)
         if not message and not raw_refs:
             yield event.plain_result(f"{MessageEmoji.WARNING} 请输入提示词或附带参考图！")
@@ -363,7 +384,8 @@ class OmniDrawPlugin(Star):
     @handle_errors
     async def cmd_selfie(self, event: AstrMessageEvent, p1: str="", p2: str="", p3: str="", p4: str="", p5: str="", p6: str="", p7: str="", p8: str="", p9: str="", p10: str="") -> AsyncGenerator[Any, None]:
         if not self._has_permission(event): return
-        message = " ".join(str(x) for x in [p1,p2,p3,p4,p5,p6,p7,p8,p9,p10] if x).strip()
+        fallback = " ".join(str(x) for x in [p1,p2,p3,p4,p5,p6,p7,p8,p9,p10] if x).strip()
+        message = self._extract_command_message(event, "自拍", fallback)
         user_input, kwargs = self.cmd_parser.parse(message)
         if not user_input: user_input = "看着镜头微笑"
         
@@ -397,7 +419,8 @@ class OmniDrawPlugin(Star):
     @handle_errors
     async def cmd_video(self, event: AstrMessageEvent, p1: str="", p2: str="", p3: str="", p4: str="", p5: str="", p6: str="", p7: str="", p8: str="", p9: str="", p10: str="") -> AsyncGenerator[Any, None]:
         if not self._has_permission(event): return
-        message = " ".join(str(x) for x in [p1,p2,p3,p4,p5,p6,p7,p8,p9,p10] if x).strip()
+        fallback = " ".join(str(x) for x in [p1,p2,p3,p4,p5,p6,p7,p8,p9,p10] if x).strip()
+        message = self._extract_command_message(event, "视频", fallback)
         raw_refs = self._get_event_images(event)
         if not message and not raw_refs: return
         prompt, _ = self.cmd_parser.parse(message)


### PR DESCRIPTION
## 问题描述

使用 `/画`、`/自拍`、`/视频` 指令时，如果提示词较长，或者尾部携带多个 `--` 参数（如 `--ar`、`--size`、`--steps` 等），超出框架分段上限（p1~p10）的部分会被完全丢弃。

## 问题原因

这三个指令依赖 AstrBot 框架通过固定位置参数（p1 ~ p10）传递用户输入，再拼接成完整消息。当提示词被空格分割超过 10 段时，第 10 段之后的内容直接丢失，`CommandParser` 根本没机会处理。

## 解决方案

新增两个辅助方法，从事件原始消息中完整提取命令内容，不再受框架分段参数上限限制：

- `_get_event_text()`：优先从 `event.message_str` / `event.message_obj.message_str` 获取原始消息全文
- `_extract_command_message()`：用正则按命令名（`/画`、`/自拍`、`/视频`）精准截取其后的完整内容

三个指令改为优先走原始消息提取，提取失败时才回退到原有的 p1~p10 拼接逻辑，兼容性和健壮性均有保障。

## 调试输出优化

- 替换 `[调试]` 标签为更直观的 `📝` 图标
- 修正附加参数计数逻辑：仅统计用户透传的 `--` 参数，不再将内部 `user_refs` 字段算入
- 调整输出格式为：`⚙️ 附加参数：N 个` 和 `🖼️ 实际参考图：N 张`

## 修复范围

- `cmd_draw` → `/画`
- `cmd_selfie` → `/自拍`
- `cmd_video` → `/视频`
