### PR TITLE
[codex] stability refactor

### DIFF
--- a/core/prompt_optimizer.py
+++ b/core/prompt_optimizer.py
@@ -3,14 +3,16 @@ import json
 import re
 import aiohttp
 import asyncio
+from typing import Optional
 from astrbot.api import logger
 from ..models import PluginConfig
+from ..providers.base import build_chat_completions_endpoint, next_api_key
 
 class PromptOptimizer:
     def __init__(self, config: PluginConfig):
         self.config = config
 
-    async def optimize(self, raw_action: str, count: int = 1) -> list:
+    async def optimize(self, raw_action: str, count: int = 1, session: Optional[aiohttp.ClientSession] = None) -> list:
         if not getattr(self.config, "enable_optimizer", True):
             return [raw_action] * count
 
@@ -18,12 +20,14 @@ class PromptOptimizer:
 
         chain = self.config.chains.get("optimizer", [])
         provider = self.config.get_provider(chain[0]) if chain else (self.config.providers[0] if self.config.providers else None)
-        if not provider or not provider.base_url or not provider.has_api_key:
+        if not provider or not provider.base_url:
             return [raw_action] * count
-            
-        base_url = provider.base_url.rstrip("/")
-        endpoint = f"{base_url}/chat/completions" if base_url.endswith("/v1") else f"{base_url}/v1/chat/completions"
-        headers = {"Authorization": f"Bearer {provider.api_keys[0]}", "Content-Type": "application/json"}
+
+        endpoint = build_chat_completions_endpoint(provider.base_url)
+        api_key = next_api_key(provider.id, provider.api_keys)
+        if not endpoint or not api_key:
+            return [raw_action] * count
+        headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
 
         # ==========================================
         # 🚀 动态风格插槽系统 (Dynamic Style Engine)
@@ -153,26 +157,32 @@ OUTPUT FORMAT:
             "response_format": {"type": "json_object"} 
         }
 
-        async with aiohttp.ClientSession() as session:
+        session_obj = session
+        close_session = False
+        if session_obj is None:
+            session_obj = aiohttp.ClientSession()
+            close_session = True
+
+        try:
             try:
                 timeout_val = self.config.optimizer_timeout * (1.5 if count > 1 else 1.0)
                 logger.info(f"🧠 [副脑] 正在以【{style_choice}】风格重构提示词 (模型: {self.config.optimizer_model})")
-                
-                async with session.post(endpoint, headers=headers, json=payload, timeout=timeout_val) as resp:
+
+                async with session_obj.post(endpoint, headers=headers, json=payload, timeout=timeout_val) as resp:
                     resp.raise_for_status()
                     data = await resp.json()
-                    
+
                     if "choices" in data and len(data["choices"]) > 0:
                         raw_content = data["choices"][0]["message"]["content"].strip()
-                        
+
                         start_idx = raw_content.find('{')
                         end_idx = raw_content.rfind('}')
                         clean_json_str = raw_content[start_idx:end_idx+1] if (start_idx != -1 and end_idx != -1 and end_idx >= start_idx) else raw_content
-                            
+
                         clean_json_str = clean_json_str.replace('\n', ' ').replace('\r', '')
                         clean_json_str = re.sub(r',\s*}', '}', clean_json_str)
                         clean_json_str = re.sub(r',\s*]', ']', clean_json_str)
-                        
+
                         items = []
                         try:
                             prompt_data = json.loads(clean_json_str)
@@ -186,39 +196,42 @@ OUTPUT FORMAT:
                             logger.warning(f"⚠️ [副脑] 原生 JSON 解析失败, 启动无敌抢救模式... 错误: {e}")
                             fallback_item = {}
                             keys = ["subject_appearance", "clothing_and_accessories", "pose_and_action", "environment_and_scene", "lighting_and_mood", "technical_specs", "realism_and_quality_guardrails"]
-                            
+
                             search_text = raw_content
                             for key in keys:
                                 idx = search_text.find(f'"{key}"')
-                                if idx == -1: continue
+                                if idx == -1:
+                                    continue
                                 colon_idx = search_text.find(':', idx)
-                                if colon_idx == -1: continue
+                                if colon_idx == -1:
+                                    continue
                                 quote_idx = search_text.find('"', colon_idx)
-                                if quote_idx == -1: continue
-                                
+                                if quote_idx == -1:
+                                    continue
+
                                 next_key_idx = len(search_text)
                                 for k in keys:
-                                    if k == key: continue
+                                    if k == key:
+                                        continue
                                     k_idx = search_text.find(f'"{k}"', quote_idx)
                                     if k_idx != -1 and k_idx < next_key_idx:
                                         next_key_idx = k_idx
-                                        
-                                raw_val = search_text[quote_idx+1:next_key_idx]
+
+                                raw_val = search_text[quote_idx + 1:next_key_idx]
                                 raw_val = raw_val.strip().rstrip('}').rstrip(']').rstrip(',').strip().rstrip('"')
                                 raw_val = raw_val.replace('"', "'").replace('\n', ' ')
                                 if raw_val:
                                     fallback_item[key] = raw_val
-                            
+
                             if fallback_item:
                                 items = [fallback_item]
                                 logger.info(f"🚑 [副脑] 抢救成功！已强行提取 {len(fallback_item)} 个字段。")
                             else:
                                 raise ValueError("抢救模式未能提取到任何有效字段")
 
-                        # 🚀 降维打击：将提取出的数据平铺为大师级自然语言流
                         results = []
                         anti_collage = "single image, one natural coherent frame, no grid, no collage, no split screen, no multiple views"
-                        
+
                         for item in items:
                             if isinstance(item, dict):
                                 parts = []
@@ -226,20 +239,22 @@ OUTPUT FORMAT:
                                     val = item.get(k, "")
                                     if val and isinstance(val, str):
                                         parts.append(val.strip())
-                                        
-                                # 融合最终长句
+
                                 master_prompt = f"{anti_collage}, " + ", ".join(parts)
                                 master_prompt = re.sub(r'\s+', ' ', master_prompt)
                                 results.append(master_prompt)
-                            
+
                         while len(results) < count:
                             results.append(results[0] if results else raw_action)
-                            
+
                         logger.info(f"✨ [副脑] 成功重构并提取 {len(results[:count])} 组【{style_choice}】提示词！")
                         return results[:count]
-                        
+
             except Exception as e:
                 logger.warning(f"⚠️ [副脑降级] ({str(e)})")
                 return [raw_action] * count
-                
-        return [raw_action] * count
+
+            return [raw_action] * count
+        finally:
+            if close_session and session_obj is not None:
+                await session_obj.close()

--- a/core/video_manager.py
+++ b/core/video_manager.py
@@ -12,6 +12,7 @@ from astrbot.api.event import AstrMessageEvent
 from astrbot.api.message_components import Plain, Video
 
 from ..models import PluginConfig, ProviderConfig
+from ..providers.base import build_chat_completions_endpoint, build_video_generations_endpoint, guess_image_content_type, next_api_key
 
 
 class VideoTaskError(Exception):
@@ -40,20 +41,21 @@ class VideoManager:
         return self.config.video_providers[:1] if self.config.video_providers else []
 
     def _get_api_key(self, provider: ProviderConfig) -> str:
-        if not provider.api_keys:
+        api_key = next_api_key(provider.id, provider.api_keys)
+        if not api_key:
             raise VideoTaskError(f"视频节点 {provider.id} 未配置 API Key。")
-        return provider.api_keys[0]
+        return api_key
 
     def _extract_url(self, text: str) -> str:
         match = re.search(r"(https?://[^\s\]\)\"']+)", text or "")
         return match.group(1) if match else text
 
     def _chat_endpoint(self, base_url: str) -> str:
-        base_url = base_url.rstrip("/")
-        return f"{base_url}/chat/completions" if base_url.endswith("/v1") else f"{base_url}/v1/chat/completions"
+        return build_chat_completions_endpoint(base_url)
 
     async def _encode_image_to_base64(self, image_ref: str, session: aiohttp.ClientSession) -> str:
         try:
+            content_type = ""
             if image_ref.startswith("data:image"):
                 return image_ref
             if image_ref.startswith("http"):
@@ -64,13 +66,15 @@ class VideoManager:
                         logger.warning(f"视频参考图下载失败，状态码: {response.status}")
                         return ""
                     image_bytes = await response.read()
+                    content_type = guess_image_content_type(image_ref, response.headers.get("Content-Type", ""))
             elif os.path.exists(image_ref):
                 with open(image_ref, "rb") as file:
                     image_bytes = file.read()
+                content_type = guess_image_content_type(image_ref)
             else:
                 logger.warning(f"视频参考图不存在: {image_ref}")
                 return ""
-            return "data:image/png;base64," + base64.b64encode(image_bytes).decode("utf-8")
+            return f"data:{content_type};base64," + base64.b64encode(image_bytes).decode("utf-8")
         except Exception as exc:
             logger.error(f"❌ 图片转 Base64 失败 ({image_ref}): {exc}")
             return ""
@@ -138,6 +142,7 @@ class VideoManager:
         self,
         provider: ProviderConfig,
         prompt: str,
+        session: aiohttp.ClientSession,
         image_urls: Optional[List[str]] = None,
         api_kwargs: Optional[Dict[str, Any]] = None,
     ) -> str:
@@ -152,73 +157,70 @@ class VideoManager:
         }
         base_url = provider.base_url.rstrip("/")
         api_type = str(provider.api_type).strip()
+        endpoint = build_video_generations_endpoint(base_url)
+        b64_images = []
+        for image_url in image_urls:
+            b64_image = await self._encode_image_to_base64(image_url, session)
+            if b64_image:
+                b64_images.append(b64_image)
 
-        async with aiohttp.ClientSession() as session:
-            b64_images = []
-            for image_url in image_urls:
-                b64_image = await self._encode_image_to_base64(image_url, session)
-                if b64_image:
-                    b64_images.append(b64_image)
+        if api_type.startswith("async_task"):
+            payload = {"model": provider.model, "prompt": prompt}
+            if b64_images:
+                payload["images"] = b64_images
+            payload.update(api_kwargs)
 
-            if api_type.startswith("async_task"):
-                endpoint = f"{base_url}/videos/generations"
-                payload = {"model": provider.model, "prompt": prompt}
-                if b64_images:
-                    payload["images"] = b64_images
-                payload.update(api_kwargs)
+            logger.info(f"🎬 [Async Task 模式] 提交视频任务至: {endpoint}")
+            async with session.post(endpoint, headers=headers, json=payload, timeout=30) as response:
+                if response.status >= 400:
+                    raise VideoTaskError(await self._read_error(response))
+                data = await response.json()
 
-                logger.info(f"🎬 [Async Task 模式] 提交视频任务至: {endpoint}")
-                async with session.post(endpoint, headers=headers, json=payload, timeout=30) as response:
-                    if response.status >= 400:
-                        raise VideoTaskError(await self._read_error(response))
-                    data = await response.json()
+            task_id = data.get("id") or data.get("task_id")
+            if not task_id and isinstance(data.get("data"), dict):
+                task_id = data["data"].get("task_id") or data["data"].get("id")
+            if not task_id:
+                raise VideoTaskError(f"提交成功但未找到任务 ID。API 原始返回: {data}")
 
-                task_id = data.get("id") or data.get("task_id")
-                if not task_id and isinstance(data.get("data"), dict):
-                    task_id = data["data"].get("task_id") or data["data"].get("id")
-                if not task_id:
-                    raise VideoTaskError(f"提交成功但未找到任务 ID。API 原始返回: {data}")
+            logger.info(f"✅ 任务提交成功，获得 Task ID: {task_id}，即将进入轮询。")
+            return await self._poll_task_result(provider, str(task_id), session)
 
-                logger.info(f"✅ 任务提交成功，获得 Task ID: {task_id}，即将进入轮询。")
-                return await self._poll_task_result(provider, str(task_id), session)
+        if api_type.startswith("openai_sync"):
+            payload = {"model": provider.model, "prompt": prompt}
+            if b64_images:
+                payload["images"] = b64_images
+                payload["image_url"] = b64_images[0]
+            payload.update(api_kwargs)
 
-            if api_type.startswith("openai_sync"):
-                endpoint = f"{base_url}/videos/generations"
-                payload = {"model": provider.model, "prompt": prompt}
-                if b64_images:
-                    payload["images"] = b64_images
-                    payload["image_url"] = b64_images[0]
-                payload.update(api_kwargs)
+            logger.info(f"🎬 [Sync 模式] 阻塞请求视频至: {endpoint}")
+            async with session.post(endpoint, headers=headers, json=payload, timeout=provider.timeout) as response:
+                if response.status >= 400:
+                    raise VideoTaskError(await self._read_error(response))
+                data = await response.json()
+            video_url = self._extract_video_url(data)
+            if video_url:
+                return video_url
+            raise VideoTaskError(f"Generations 同步返回值异常，未找到视频链接: {data}")
 
-                logger.info(f"🎬 [Sync 模式] 阻塞请求视频至: {endpoint}")
-                async with session.post(endpoint, headers=headers, json=payload, timeout=provider.timeout) as response:
-                    if response.status >= 400:
-                        raise VideoTaskError(await self._read_error(response))
-                    data = await response.json()
-                video_url = self._extract_video_url(data)
-                if video_url:
-                    return video_url
-                raise VideoTaskError(f"Generations 同步返回值异常，未找到视频链接: {data}")
+        if api_type.startswith("openai_chat"):
+            endpoint = self._chat_endpoint(base_url)
+            content = [{"type": "text", "text": prompt}]
+            for b64_image in b64_images:
+                content.append({"type": "image_url", "image_url": {"url": b64_image}})
+            payload = {"model": provider.model, "messages": [{"role": "user", "content": content}]}
+            payload.update(api_kwargs)
 
-            if api_type.startswith("openai_chat"):
-                endpoint = self._chat_endpoint(base_url)
-                content = [{"type": "text", "text": prompt}]
-                for b64_image in b64_images:
-                    content.append({"type": "image_url", "image_url": {"url": b64_image}})
-                payload = {"model": provider.model, "messages": [{"role": "user", "content": content}]}
-                payload.update(api_kwargs)
+            logger.info(f"🎬 [Chat 模式] 请求视频至: {endpoint}")
+            async with session.post(endpoint, headers=headers, json=payload, timeout=provider.timeout) as response:
+                if response.status >= 400:
+                    raise VideoTaskError(await self._read_error(response))
+                data = await response.json()
+            if data.get("choices"):
+                raw_content = data["choices"][0].get("message", {}).get("content", "")
+                return self._extract_url(str(raw_content))
+            raise VideoTaskError(f"Chat 返回值异常: {data}")
 
-                logger.info(f"🎬 [Chat 模式] 请求视频至: {endpoint}")
-                async with session.post(endpoint, headers=headers, json=payload, timeout=provider.timeout) as response:
-                    if response.status >= 400:
-                        raise VideoTaskError(await self._read_error(response))
-                    data = await response.json()
-                if data.get("choices"):
-                    raw_content = data["choices"][0].get("message", {}).get("content", "")
-                    return self._extract_url(str(raw_content))
-                raise VideoTaskError(f"Chat 返回值异常: {data}")
-
-            raise VideoTaskError(f"不受支持的接口模式: {api_type}，请在后台重新选择调用协议。")
+        raise VideoTaskError(f"不受支持的接口模式: {api_type}，请在后台重新选择调用协议。")
 
     async def background_task_runner(
         self,
@@ -235,25 +237,26 @@ class VideoManager:
 
         last_error = ""
         try:
-            for index, provider in enumerate(providers, start=1):
-                logger.info(f"🎬 [视频链路] 正在尝试节点 [{provider.id}] ({index}/{len(providers)})。")
-                try:
-                    video_url = await self._fetch_video_from_api(provider, prompt, image_urls, api_kwargs)
-                    elapsed = time.perf_counter() - start_time
-                    logger.info(f"✅ [视频任务完成] 节点 [{provider.id}] 成功，耗时: {elapsed:.2f} 秒，准备推送给用户。")
+            async with aiohttp.ClientSession() as session:
+                for index, provider in enumerate(providers, start=1):
+                    logger.info(f"🎬 [视频链路] 正在尝试节点 [{provider.id}] ({index}/{len(providers)})。")
+                    try:
+                        video_url = await self._fetch_video_from_api(provider, prompt, session, image_urls, api_kwargs)
+                        elapsed = time.perf_counter() - start_time
+                        logger.info(f"✅ [视频任务完成] 节点 [{provider.id}] 成功，耗时: {elapsed:.2f} 秒，准备推送给用户。")
 
-                    if not video_url:
-                        raise VideoTaskError("API 没有返回有效视频链接。")
-                    await event.send(event.chain_result([
-                        Plain(f"🎬 当当当！历时 {int(elapsed)} 秒，你要求的视频渲染完成啦：\n"),
-                        Video.fromURL(video_url),
-                    ]))
-                    return
-                except VideoTaskError as exc:
-                    last_error = f"{provider.id}: {exc}"
-                    logger.error(f"❌ [视频链路] 节点 [{provider.id}] 失败: {exc}")
-                    if index < len(providers):
-                        logger.warning("🔄 正在切换到下一个视频备用节点...")
+                        if not video_url:
+                            raise VideoTaskError("API 没有返回有效视频链接。")
+                        await event.send(event.chain_result([
+                            Plain(f"🎬 当当当！历时 {int(elapsed)} 秒，你要求的视频渲染完成啦：\n"),
+                            Video.fromURL(video_url),
+                        ]))
+                        return
+                    except VideoTaskError as exc:
+                        last_error = f"{provider.id}: {exc}"
+                        logger.error(f"❌ [视频链路] 节点 [{provider.id}] 失败: {exc}")
+                        if index < len(providers):
+                            logger.warning("🔄 正在切换到下一个视频备用节点...")
 
             raise VideoTaskError(f"所有视频节点均失败。最后一次错误：{last_error or '未知错误'}")
         except VideoTaskError as exc:

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ import mimetypes
 import os
 import random
 import re
+import threading
 import time
 import uuid
 from urllib.parse import parse_qs, urlparse
@@ -59,7 +60,7 @@ from .core.persona_manager import PersonaManager
 from .core.prompt_optimizer import PromptOptimizer
 from .core.video_manager import VideoManager
 from .models import PLUGIN_AUTHOR, PLUGIN_NAME, PLUGIN_VERSION, PluginConfig
-from .utils import handle_errors
+from .utils import handle_errors, save_image_bytes, split_data_url
 
 PAGE_PREVIEW_IMAGE_BYTES = 80 * 1024 * 1024
 NATIVE_ACTIVE_PERSONA_FILE_PREFIX = "files/persona_config/persona_ref_image/"
@@ -106,6 +107,8 @@ class OmniDrawPlugin(Star):
         self.usage_stats_path = os.path.join(self.data_dir, "omnidraw_usage_stats.json")
         self._usage_stats = self._load_usage_stats()
         self._background_tasks = set()
+        self._config_lock = threading.RLock()
+        self._usage_lock = threading.RLock()
         self._cache_cleanup_task: Optional[asyncio.Task] = None
         self._page_image_tokens: Dict[str, str] = {}
         self._native_config = config if hasattr(config, "save_config") else None
@@ -239,23 +242,25 @@ class OmniDrawPlugin(Star):
         }
 
     def _current_usage_stats(self) -> Dict[str, Any]:
-        self._usage_stats = self._normalize_usage_stats(self._usage_stats)
-        return self._usage_stats
+        with self._usage_lock:
+            self._usage_stats = self._normalize_usage_stats(self._usage_stats)
+            return self._usage_stats
 
     def _persist_usage_stats(self) -> None:
-        os.makedirs(self.data_dir, exist_ok=True)
-        tmp_path = f"{self.usage_stats_path}.{uuid.uuid4().hex}.tmp"
-        try:
-            with open(tmp_path, "w", encoding="utf-8") as file:
-                json.dump(self._current_usage_stats(), file, ensure_ascii=False, indent=4)
-            os.replace(tmp_path, self.usage_stats_path)
-        except Exception as exc:
-            logger.error(f"[OmniDraw] 生图统计保存失败: {exc}", exc_info=True)
+        with self._usage_lock:
+            os.makedirs(self.data_dir, exist_ok=True)
+            tmp_path = f"{self.usage_stats_path}.{uuid.uuid4().hex}.tmp"
             try:
-                if os.path.exists(tmp_path):
-                    os.remove(tmp_path)
-            except OSError:
-                pass
+                with open(tmp_path, "w", encoding="utf-8") as file:
+                    json.dump(self._current_usage_stats(), file, ensure_ascii=False, indent=4)
+                os.replace(tmp_path, self.usage_stats_path)
+            except Exception as exc:
+                logger.error(f"[OmniDraw] 生图统计保存失败: {exc}", exc_info=True)
+                try:
+                    if os.path.exists(tmp_path):
+                        os.remove(tmp_path)
+                except OSError:
+                    pass
 
     def _usage_stats_for_page(self) -> Dict[str, Any]:
         stats = self._current_usage_stats()
@@ -554,12 +559,13 @@ class OmniDrawPlugin(Star):
         self._prune_cache_if_needed("config_reload")
 
     def _persist_config(self) -> None:
-        os.makedirs(self.data_dir, exist_ok=True)
-        tmp_path = f"{self.config_path}.{uuid.uuid4().hex}.tmp"
-        with open(tmp_path, "w", encoding="utf-8") as file:
-            json.dump(self.raw_config, file, ensure_ascii=False, indent=4)
-        os.replace(tmp_path, self.config_path)
-        self._persist_config_mtime = self._get_mtime(self.config_path)
+        with self._config_lock:
+            os.makedirs(self.data_dir, exist_ok=True)
+            tmp_path = f"{self.config_path}.{uuid.uuid4().hex}.tmp"
+            with open(tmp_path, "w", encoding="utf-8") as file:
+                json.dump(self.raw_config, file, ensure_ascii=False, indent=4)
+            os.replace(tmp_path, self.config_path)
+            self._persist_config_mtime = self._get_mtime(self.config_path)
 
     def _safe_update_context_config(self) -> None:
         if self._native_config is not None and hasattr(self._native_config, "save_config"):
@@ -584,23 +590,24 @@ class OmniDrawPlugin(Star):
     def _refresh_from_native_config_if_changed(self) -> None:
         if not self._native_config_path:
             return
-        current_mtime = self._get_mtime(self._native_config_path)
-        current_signature = self._file_signature(self._native_config_path)
-        if current_signature and current_signature == self._native_config_signature:
-            return
-        native_config = self._clean_runtime_config(self._load_json_file(self._native_config_path))
-        if not native_config:
+        with self._config_lock:
+            current_mtime = self._get_mtime(self._native_config_path)
+            current_signature = self._file_signature(self._native_config_path)
+            if current_signature and current_signature == self._native_config_signature:
+                return
+            native_config = self._clean_runtime_config(self._load_json_file(self._native_config_path))
+            if not native_config:
+                self._native_config_mtime = current_mtime
+                self._native_config_signature = current_signature
+                return
+            self._apply_runtime_config(native_config)
+            self._persist_config()
             self._native_config_mtime = current_mtime
             self._native_config_signature = current_signature
-            return
-        self._apply_runtime_config(native_config)
-        self._persist_config()
-        self._native_config_mtime = current_mtime
-        self._native_config_signature = current_signature
-        if self._native_config is not None:
-            self._native_config.clear()
-            self._native_config.update(self._config_for_native_page())
-        logger.info("[OmniDraw] 已从 AstrBot 原生配置热同步最新设置。")
+            if self._native_config is not None:
+                self._native_config.clear()
+                self._native_config.update(self._config_for_native_page())
+            logger.info("[OmniDraw] 已从 AstrBot 原生配置热同步最新设置。")
 
     async def get_config_handler(self):
         self._refresh_from_native_config_if_changed()
@@ -608,11 +615,13 @@ class OmniDrawPlugin(Star):
 
     async def get_usage_stats_handler(self):
         self._refresh_from_native_config_if_changed()
-        return jsonify({"success": True, "stats": self._usage_stats_for_page()})
+        stats = await asyncio.to_thread(self._usage_stats_for_page)
+        return jsonify({"success": True, "stats": stats})
 
     async def get_cache_stats_handler(self):
         self._refresh_from_native_config_if_changed()
-        return jsonify({"success": True, "stats": self._cache_stats_for_page()})
+        stats = await asyncio.to_thread(self._cache_stats_for_page)
+        return jsonify({"success": True, "stats": stats})
 
     def _config_for_page(self) -> Dict[str, Any]:
         self._page_image_tokens.clear()
@@ -743,10 +752,11 @@ class OmniDrawPlugin(Star):
             return jsonify({"success": False, "message": "配置格式错误：请求体必须是 JSON 对象。"}), 400
 
         try:
-            self._normalize_saved_page_images(new_config)
-            self._apply_runtime_config(new_config)
-            self._persist_config()
-            self._safe_update_context_config()
+            with self._config_lock:
+                self._normalize_saved_page_images(new_config)
+                self._apply_runtime_config(new_config)
+                self._persist_config()
+                self._safe_update_context_config()
         except Exception as exc:
             logger.error(f"[OmniDraw] 配置保存失败: {exc}", exc_info=True)
             return jsonify({"success": False, "message": f"配置保存失败: {exc}"}), 500
@@ -756,8 +766,9 @@ class OmniDrawPlugin(Star):
 
     async def clear_cache_handler(self):
         self._refresh_from_native_config_if_changed()
-        result = self._clear_cache_images(reason="webui")
-        return jsonify({"success": True, "message": "缓存已清理。", "cleanup": result, "stats": self._cache_stats_for_page()})
+        result = await asyncio.to_thread(lambda: self._clear_cache_images(reason="webui"))
+        stats = await asyncio.to_thread(self._cache_stats_for_page)
+        return jsonify({"success": True, "message": "缓存已清理。", "cleanup": result, "stats": stats})
 
     def _create_background_task(self, coro: Any) -> asyncio.Task:
         task = asyncio.create_task(coro)
@@ -1098,7 +1109,7 @@ class OmniDrawPlugin(Star):
             chunks.append(chunk)
         return b"".join(chunks)
 
-    async def _process_and_save_images(self, raw_images: Iterable[str]) -> List[str]:
+    async def _process_and_save_images(self, raw_images: Iterable[str], session: Optional[aiohttp.ClientSession] = None) -> List[str]:
         processed_paths = []
         if not raw_images:
             return processed_paths
@@ -1107,21 +1118,28 @@ class OmniDrawPlugin(Star):
         os.makedirs(save_dir, exist_ok=True)
         headers = {"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"}
 
-        async with aiohttp.ClientSession() as session:
-            for img_ref in raw_images:
+        session_obj = session
+        session_owner = False
+        try:
+            for idx, img_ref in enumerate(raw_images):
                 if not img_ref:
                     continue
                 img_ref = str(img_ref)
 
                 if img_ref.startswith("data:image"):
                     try:
-                        b64_data = img_ref.split(",", 1)[1]
-                        decoded = base64.b64decode(b64_data, validate=False)
+                        decoded, content_type = split_data_url(img_ref)
                         if len(decoded) > MAX_IMAGE_BYTES:
                             raise ValueError("Base64 图片超过大小限制")
-                        file_path = os.path.join(save_dir, f"ref_{uuid.uuid4().hex[:12]}.png")
-                        with open(file_path, "wb") as file:
-                            file.write(decoded)
+                        file_path = await asyncio.to_thread(
+                            save_image_bytes,
+                            decoded,
+                            save_dir,
+                            img_ref,
+                            "ref",
+                            idx,
+                            content_type,
+                        )
                         processed_paths.append(file_path)
                     except (IndexError, ValueError, binascii.Error, OSError) as exc:
                         logger.warning(f"[OmniDraw] Base64 参考图处理失败: {exc}")
@@ -1135,16 +1153,26 @@ class OmniDrawPlugin(Star):
                         logger.warning(f"[OmniDraw] 本地参考图不存在: {abs_path}")
                     continue
 
+                if session_obj is None:
+                    session_obj = aiohttp.ClientSession()
+                    session_owner = True
+
                 for attempt in range(1, 4):
                     try:
-                        async with session.get(img_ref, headers=headers, timeout=15) as response:
+                        async with session_obj.get(img_ref, headers=headers, timeout=15) as response:
                             if response.status != 200:
                                 logger.warning(f"[OmniDraw] 下载参考图失败，状态码 {response.status}: {img_ref}")
                                 continue
                             img_data = await self._read_response_limited(response)
-                            file_path = os.path.join(save_dir, f"ref_{uuid.uuid4().hex[:12]}.png")
-                            with open(file_path, "wb") as file:
-                                file.write(img_data)
+                            file_path = await asyncio.to_thread(
+                                save_image_bytes,
+                                img_data,
+                                save_dir,
+                                img_ref,
+                                "ref",
+                                idx,
+                                response.headers.get("Content-Type", ""),
+                            )
                             processed_paths.append(file_path)
                             break
                     except Exception as exc:
@@ -1153,7 +1181,10 @@ class OmniDrawPlugin(Star):
                         else:
                             await asyncio.sleep(1)
 
-        self._prune_cache_if_needed("user_refs", protected_paths=processed_paths)
+            await asyncio.to_thread(lambda: self._prune_cache_if_needed("user_refs", protected_paths=processed_paths))
+        finally:
+            if session_owner:
+                await session_obj.close()
         return processed_paths
 
     def _normalize_count(self, count: Any) -> int:
@@ -1391,25 +1422,26 @@ class OmniDrawPlugin(Star):
         if count <= 0:
             return
 
-        stats = self._current_usage_stats()
-        status = self._access_status(event, refresh=False)
-        user_id = status.get("user_id") or self._get_event_user_id(event)
-        users = stats.setdefault("users", {})
-        record = users.setdefault(user_id, {"user_id": user_id, "count": 0, "last_at": 0, "bonus": 0, "checkin_at": 0})
-        record["user_id"] = user_id
-        record["count"] = self._to_nonnegative_int(record.get("count", 0)) + count
-        record["bonus"] = self._to_nonnegative_int(record.get("bonus", 0))
-        record["checkin_at"] = self._to_nonnegative_int(record.get("checkin_at", 0))
-        record["last_at"] = int(time.time())
-        record["access_level"] = str(status.get("level") or "limited")
-        group_id = status.get("group_id") or self._get_event_group_id(event)
-        if group_id:
-            record["group_id"] = group_id
-        display_name = self._get_event_user_label(event).strip()
-        if display_name and display_name != user_id:
-            record["display_name"] = display_name
-        stats["total"] = sum(self._to_nonnegative_int(item.get("count", 0)) for item in users.values())
-        self._persist_usage_stats()
+        with self._usage_lock:
+            stats = self._current_usage_stats()
+            status = self._access_status(event, refresh=False)
+            user_id = status.get("user_id") or self._get_event_user_id(event)
+            users = stats.setdefault("users", {})
+            record = users.setdefault(user_id, {"user_id": user_id, "count": 0, "last_at": 0, "bonus": 0, "checkin_at": 0})
+            record["user_id"] = user_id
+            record["count"] = self._to_nonnegative_int(record.get("count", 0)) + count
+            record["bonus"] = self._to_nonnegative_int(record.get("bonus", 0))
+            record["checkin_at"] = self._to_nonnegative_int(record.get("checkin_at", 0))
+            record["last_at"] = int(time.time())
+            record["access_level"] = str(status.get("level") or "limited")
+            group_id = status.get("group_id") or self._get_event_group_id(event)
+            if group_id:
+                record["group_id"] = group_id
+            display_name = self._get_event_user_label(event).strip()
+            if display_name and display_name != user_id:
+                record["display_name"] = display_name
+            stats["total"] = sum(self._to_nonnegative_int(item.get("count", 0)) for item in users.values())
+            self._persist_usage_stats()
 
     def _has_permission(self, event: AstrMessageEvent) -> bool:
         return bool(self._access_status(event).get("allowed", True))
@@ -1435,12 +1467,9 @@ class OmniDrawPlugin(Star):
 
     def _create_image_component(self, image_url: str) -> Image:
         if image_url.startswith("data:image"):
-            b64_data = image_url.split(",", 1)[1]
+            image_bytes, content_type = split_data_url(image_url)
             save_dir = os.path.join(self.data_dir, "temp_images")
-            os.makedirs(save_dir, exist_ok=True)
-            file_path = os.path.join(save_dir, f"img_{uuid.uuid4().hex[:12]}.png")
-            with open(file_path, "wb") as file:
-                file.write(base64.b64decode(b64_data, validate=False))
+            file_path = save_image_bytes(image_bytes, save_dir, image_url, "img", 0, content_type)
             self._prune_cache_if_needed("temp_images", protected_paths=[file_path])
             return Image.fromFileSystem(file_path)
         if image_url.startswith("http"):
@@ -1594,7 +1623,7 @@ class OmniDrawPlugin(Star):
     @filter.command("清理缓存")
     @handle_errors
     async def cmd_clear_cache(self, event: AstrMessageEvent) -> AsyncGenerator[Any, None]:
-        result = self._clear_cache_images(reason="command")
+        result = await asyncio.to_thread(lambda: self._clear_cache_images(reason="command"))
         yield event.plain_result(
             f"{MessageEmoji.SUCCESS} 缓存清理完成：删除 {result['deleted_count']} 个图片文件，"
             f"释放 {result['human_deleted_size']}。\n"
@@ -1618,43 +1647,45 @@ class OmniDrawPlugin(Star):
             yield event.plain_result(f"{MessageEmoji.INFO} 当前未启用签到领额度。")
             return
 
-        stats = self._current_usage_stats()
-        users = stats.setdefault("users", {})
-        user_id = status.get("user_id") or self._get_event_user_id(event)
-        record = users.setdefault(user_id, {"user_id": user_id, "count": 0, "last_at": 0, "bonus": 0, "checkin_at": 0})
-        used = self._to_nonnegative_int(record.get("count", 0))
-        bonus = self._to_nonnegative_int(record.get("bonus", 0))
-        checkin_at = self._to_nonnegative_int(record.get("checkin_at", 0))
-        base_limit = self._daily_image_limit()
-        if checkin_at > 0:
-            yield event.plain_result(
-                f"{MessageEmoji.INFO} 今日已经签到过啦：额外额度 +{bonus} 张，"
-                f"当前已使用 {used}/{base_limit + bonus} 张。"
-            )
-            return
-
-        bonus_min = self._to_nonnegative_int(getattr(self.plugin_config, "checkin_bonus_min", 1), 1)
-        bonus_max = self._to_nonnegative_int(getattr(self.plugin_config, "checkin_bonus_max", 3), 3)
-        if bonus_max < bonus_min:
-            bonus_max = bonus_min
-        gained = random.randint(bonus_min, bonus_max) if bonus_max > bonus_min else bonus_min
-        record["user_id"] = user_id
-        record["count"] = used
-        record["bonus"] = bonus + gained
-        record["checkin_at"] = int(time.time())
-        record["access_level"] = "limited"
-        group_id = status.get("group_id") or self._get_event_group_id(event)
-        if group_id:
-            record["group_id"] = group_id
-        display_name = self._get_event_user_label(event).strip()
-        if display_name and display_name != user_id:
-            record["display_name"] = display_name
-        stats["total"] = sum(self._to_nonnegative_int(item.get("count", 0)) for item in users.values())
-        self._persist_usage_stats()
-        yield event.plain_result(
-            f"{MessageEmoji.SUCCESS} 签到成功，今日额外生图额度 +{gained} 张。"
-            f"当前额度 {used}/{base_limit + bonus + gained} 张。"
-        )
+        reply = ""
+        with self._usage_lock:
+            stats = self._current_usage_stats()
+            users = stats.setdefault("users", {})
+            user_id = status.get("user_id") or self._get_event_user_id(event)
+            record = users.setdefault(user_id, {"user_id": user_id, "count": 0, "last_at": 0, "bonus": 0, "checkin_at": 0})
+            used = self._to_nonnegative_int(record.get("count", 0))
+            bonus = self._to_nonnegative_int(record.get("bonus", 0))
+            checkin_at = self._to_nonnegative_int(record.get("checkin_at", 0))
+            base_limit = self._daily_image_limit()
+            if checkin_at > 0:
+                reply = (
+                    f"{MessageEmoji.INFO} 今日已经签到过啦：额外额度 +{bonus} 张，"
+                    f"当前已使用 {used}/{base_limit + bonus} 张。"
+                )
+            else:
+                bonus_min = self._to_nonnegative_int(getattr(self.plugin_config, "checkin_bonus_min", 1), 1)
+                bonus_max = self._to_nonnegative_int(getattr(self.plugin_config, "checkin_bonus_max", 3), 3)
+                if bonus_max < bonus_min:
+                    bonus_max = bonus_min
+                gained = random.randint(bonus_min, bonus_max) if bonus_max > bonus_min else bonus_min
+                record["user_id"] = user_id
+                record["count"] = used
+                record["bonus"] = bonus + gained
+                record["checkin_at"] = int(time.time())
+                record["access_level"] = "limited"
+                group_id = status.get("group_id") or self._get_event_group_id(event)
+                if group_id:
+                    record["group_id"] = group_id
+                display_name = self._get_event_user_label(event).strip()
+                if display_name and display_name != user_id:
+                    record["display_name"] = display_name
+                stats["total"] = sum(self._to_nonnegative_int(item.get("count", 0)) for item in users.values())
+                self._persist_usage_stats()
+                reply = (
+                    f"{MessageEmoji.SUCCESS} 签到成功，今日额外生图额度 +{gained} 张。"
+                    f"当前额度 {used}/{base_limit + bonus + gained} 张。"
+                )
+        yield event.plain_result(reply)
 
     @filter.command("人设")
     @handle_errors
@@ -1819,25 +1850,25 @@ class OmniDrawPlugin(Star):
             yield event.plain_result(quota_error)
             return
 
-        raw_refs = self._get_event_images(event)
-        preset_prompt = self.plugin_config.presets[cmd_name]
-        safe_refs = await self._process_and_save_images(raw_refs)
-
-        msg = self._format_pending_message(
-            self.plugin_config.draw_pending_message,
-            DEFAULT_DRAW_PENDING_MESSAGE,
-            command=cmd_name,
-            prompt=preset_prompt,
-            ref_count=len(safe_refs),
-            param_count=0,
-            persona_name=self.plugin_config.persona_name,
-        )
-        if self.plugin_config.verbose_report:
-            msg += f"\n📝 宏对应提示词: {preset_prompt}\n🖼️ 实际参考图：{len(safe_refs)} 张"
-        yield event.plain_result(msg)
-
         try:
             async with aiohttp.ClientSession() as session:
+                raw_refs = self._get_event_images(event)
+                preset_prompt = self.plugin_config.presets[cmd_name]
+                safe_refs = await self._process_and_save_images(raw_refs, session=session)
+
+                msg = self._format_pending_message(
+                    self.plugin_config.draw_pending_message,
+                    DEFAULT_DRAW_PENDING_MESSAGE,
+                    command=cmd_name,
+                    prompt=preset_prompt,
+                    ref_count=len(safe_refs),
+                    param_count=0,
+                    persona_name=self.plugin_config.persona_name,
+                )
+                if self.plugin_config.verbose_report:
+                    msg += f"\n📝 宏对应提示词: {preset_prompt}\n🖼️ 实际参考图：{len(safe_refs)} 张"
+                yield event.plain_result(msg)
+
                 chain_manager = ChainManager(self.plugin_config, session)
                 image_url = await chain_manager.run_chain("text2img", preset_prompt, user_refs=safe_refs)
             self._record_generated_images(event, 1)
@@ -1879,28 +1910,28 @@ class OmniDrawPlugin(Star):
             yield event.plain_result(f"{MessageEmoji.WARNING} 请输入提示词或附带参考图。")
             return
 
-        safe_refs = await self._process_and_save_images(raw_refs)
-        prompt, kwargs = self.cmd_parser.parse(message)
-        if not prompt and safe_refs:
-            prompt = "根据参考图生成一张自然、清晰、符合原图语义的图片。"
-        param_count = len(kwargs)
-        if safe_refs:
-            kwargs["user_refs"] = safe_refs
-
-        msg = self._format_pending_message(
-            self.plugin_config.draw_pending_message,
-            DEFAULT_DRAW_PENDING_MESSAGE,
-            command="画",
-            prompt=prompt,
-            ref_count=len(safe_refs),
-            param_count=param_count,
-            persona_name=self.plugin_config.persona_name,
-        )
-        if self.plugin_config.verbose_report:
-            msg += f"\n📝 最终提示词: {prompt}\n⚙️ 附加参数：{param_count} 个\n🖼️ 实际参考图：{len(safe_refs)} 张"
-        yield event.plain_result(msg)
-
         async with aiohttp.ClientSession() as session:
+            safe_refs = await self._process_and_save_images(raw_refs, session=session)
+            prompt, kwargs = self.cmd_parser.parse(message)
+            if not prompt and safe_refs:
+                prompt = "根据参考图生成一张自然、清晰、符合原图语义的图片。"
+            param_count = len(kwargs)
+            if safe_refs:
+                kwargs["user_refs"] = safe_refs
+
+            msg = self._format_pending_message(
+                self.plugin_config.draw_pending_message,
+                DEFAULT_DRAW_PENDING_MESSAGE,
+                command="画",
+                prompt=prompt,
+                ref_count=len(safe_refs),
+                param_count=param_count,
+                persona_name=self.plugin_config.persona_name,
+            )
+            if self.plugin_config.verbose_report:
+                msg += f"\n📝 最终提示词: {prompt}\n⚙️ 附加参数：{param_count} 个\n🖼️ 实际参考图：{len(safe_refs)} 张"
+            yield event.plain_result(msg)
+
             chain_manager = ChainManager(self.plugin_config, session)
             image_url = await chain_manager.run_chain("text2img", prompt, **kwargs)
         self._record_generated_images(event, 1)
@@ -1936,34 +1967,34 @@ class OmniDrawPlugin(Star):
         user_input, kwargs = self.cmd_parser.parse(message)
         user_input = user_input or "看着镜头微笑"
 
-        optimized_actions = await self.prompt_optimizer.optimize(user_input, count=1)
-        final_prompt, extra_kwargs = self.persona_manager.build_persona_prompt(optimized_actions[0] if optimized_actions else user_input)
-        extra_kwargs.update(kwargs)
-
-        raw_refs = self._get_event_images(event)
-        target_refs = raw_refs if raw_refs else self.plugin_config.persona_ref_images
-        safe_refs = await self._process_and_save_images(target_refs)
-        if safe_refs:
-            extra_kwargs["user_refs"] = safe_refs
-            if not raw_refs:
-                extra_kwargs.pop("persona_ref", None)
-
-        msg = self._format_pending_message(
-            self.plugin_config.selfie_pending_message,
-            DEFAULT_SELFIE_PENDING_MESSAGE,
-            command="自拍",
-            prompt=final_prompt,
-            user_input=user_input,
-            ref_count=len(safe_refs),
-            param_count=len(kwargs),
-            persona_name=self.plugin_config.persona_name,
-        )
-        if self.plugin_config.verbose_report:
-            msg += f"\n📝 构建提示词: {final_prompt}\n⚙️ 附加参数：{len(kwargs)} 个\n🖼️ 实际参考图：{len(safe_refs)} 张"
-        yield event.plain_result(msg)
-
-        chain_to_use = "selfie" if self.plugin_config.chains.get("selfie") else "text2img"
         async with aiohttp.ClientSession() as session:
+            optimized_actions = await self.prompt_optimizer.optimize(user_input, count=1, session=session)
+            final_prompt, extra_kwargs = self.persona_manager.build_persona_prompt(optimized_actions[0] if optimized_actions else user_input)
+            extra_kwargs.update(kwargs)
+
+            raw_refs = self._get_event_images(event)
+            target_refs = raw_refs if raw_refs else self.plugin_config.persona_ref_images
+            safe_refs = await self._process_and_save_images(target_refs, session=session)
+            if safe_refs:
+                extra_kwargs["user_refs"] = safe_refs
+                if not raw_refs:
+                    extra_kwargs.pop("persona_ref", None)
+
+            msg = self._format_pending_message(
+                self.plugin_config.selfie_pending_message,
+                DEFAULT_SELFIE_PENDING_MESSAGE,
+                command="自拍",
+                prompt=final_prompt,
+                user_input=user_input,
+                ref_count=len(safe_refs),
+                param_count=len(kwargs),
+                persona_name=self.plugin_config.persona_name,
+            )
+            if self.plugin_config.verbose_report:
+                msg += f"\n📝 构建提示词: {final_prompt}\n⚙️ 附加参数：{len(kwargs)} 个\n🖼️ 实际参考图：{len(safe_refs)} 张"
+            yield event.plain_result(msg)
+
+            chain_to_use = "selfie" if self.plugin_config.chains.get("selfie") else "text2img"
             chain_manager = ChainManager(self.plugin_config, session)
             image_url = await chain_manager.run_chain(chain_to_use, final_prompt, **extra_kwargs)
         self._record_generated_images(event, 1)
@@ -1997,7 +2028,14 @@ class OmniDrawPlugin(Star):
             yield event.plain_result(f"{MessageEmoji.WARNING} 请输入视频提示词或附带参考图。")
             return
 
-        safe_refs = await self._process_and_save_images(raw_refs)
+        safe_refs = []
+        if raw_refs:
+            needs_session = any(str(ref).startswith("http") for ref in raw_refs)
+            if needs_session:
+                async with aiohttp.ClientSession() as session:
+                    safe_refs = await self._process_and_save_images(raw_refs, session=session)
+            else:
+                safe_refs = await self._process_and_save_images(raw_refs)
         prompt, kwargs = self.cmd_parser.parse(message)
         if not prompt and safe_refs:
             prompt = "根据参考图生成一段自然、流畅、清晰的视频。"
@@ -2037,14 +2075,14 @@ class OmniDrawPlugin(Star):
             quota_error = self._image_quota_error_message(event, count)
             if quota_error:
                 return quota_error
-            optimized_actions = await self.prompt_optimizer.optimize(action or "看着镜头微笑", count)
-            raw_refs = self._get_event_images(event)
-            target_refs = raw_refs if raw_refs else self.plugin_config.persona_ref_images
-            safe_refs = await self._process_and_save_images(target_refs)
-            extra_param_kwargs = self._parse_extra_params(extra_params)
-
-            chain_to_use = "selfie" if self.plugin_config.chains.get("selfie") else "text2img"
             async with aiohttp.ClientSession() as session:
+                optimized_actions = await self.prompt_optimizer.optimize(action or "看着镜头微笑", count, session=session)
+                raw_refs = self._get_event_images(event)
+                target_refs = raw_refs if raw_refs else self.plugin_config.persona_ref_images
+                safe_refs = await self._process_and_save_images(target_refs, session=session)
+                extra_param_kwargs = self._parse_extra_params(extra_params)
+
+                chain_to_use = "selfie" if self.plugin_config.chains.get("selfie") else "text2img"
                 chain_manager = ChainManager(self.plugin_config, session)
                 tasks = []
                 for optimized_action in optimized_actions:
@@ -2099,17 +2137,17 @@ class OmniDrawPlugin(Star):
             quota_error = self._image_quota_error_message(event, count)
             if quota_error:
                 return quota_error
-            optimized_actions = await self.prompt_optimizer.optimize(prompt, count)
-            safe_refs = await self._process_and_save_images(self._get_event_images(event))
-
-            kwargs = {"user_refs": safe_refs} if safe_refs else {}
-            if aspect_ratio:
-                kwargs["aspect_ratio"] = aspect_ratio
-            if size:
-                kwargs["size"] = size
-            kwargs.update(self._parse_extra_params(extra_params))
-
             async with aiohttp.ClientSession() as session:
+                optimized_actions = await self.prompt_optimizer.optimize(prompt, count, session=session)
+                safe_refs = await self._process_and_save_images(self._get_event_images(event), session=session)
+
+                kwargs = {"user_refs": safe_refs} if safe_refs else {}
+                if aspect_ratio:
+                    kwargs["aspect_ratio"] = aspect_ratio
+                if size:
+                    kwargs["size"] = size
+                kwargs.update(self._parse_extra_params(extra_params))
+
                 chain_manager = ChainManager(self.plugin_config, session)
                 tasks = [chain_manager.run_chain("text2img", optimized_action, **kwargs) for optimized_action in optimized_actions]
                 results = await asyncio.gather(*tasks, return_exceptions=True)
@@ -2149,7 +2187,15 @@ class OmniDrawPlugin(Star):
 
         try:
             count = self._normalize_count(count)
-            safe_refs = await self._process_and_save_images(self._get_event_images(event))
+            raw_refs = self._get_event_images(event)
+            safe_refs = []
+            if raw_refs:
+                needs_session = any(str(ref).startswith("http") for ref in raw_refs)
+                if needs_session:
+                    async with aiohttp.ClientSession() as session:
+                        safe_refs = await self._process_and_save_images(raw_refs, session=session)
+                else:
+                    safe_refs = await self._process_and_save_images(raw_refs)
             kwargs = self._parse_extra_params(extra_params)
             if aspect_ratio:
                 kwargs["aspect_ratio"] = aspect_ratio

--- a/models.py
+++ b/models.py
@@ -1,11 +1,9 @@
 """
 AstrBot 万象画卷插件 - 数据模型与配置归一化。
 """
-import base64
 import binascii
 import os
 import re
-import time
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Set, Tuple
 
@@ -15,6 +13,7 @@ from .constants import (
     DEFAULT_SELFIE_ERROR_MESSAGE,
     DEFAULT_SELFIE_PENDING_MESSAGE,
 )
+from .utils import save_image_bytes, split_data_url
 
 PLUGIN_NAME = "astrbot_plugin_omnidraw"
 PLUGIN_AUTHOR = "雪碧bir"
@@ -561,17 +560,8 @@ def _is_page_preview_ref(image_ref: str) -> bool:
 
 def _save_data_url_image(data_url: str, refs_dir: str, idx: int) -> str:
     try:
-        header, base64_str = data_url.split(",", 1)
-        ext = "png"
-        if "jpeg" in header or "jpg" in header:
-            ext = "jpg"
-        elif "webp" in header:
-            ext = "webp"
-        filename = f"ref_{int(time.time() * 1000)}_{idx}.{ext}"
-        filepath = os.path.join(refs_dir, filename)
-        with open(filepath, "wb") as file:
-            file.write(base64.b64decode(base64_str, validate=False))
-        return filepath
+        image_bytes, content_type = split_data_url(data_url)
+        return save_image_bytes(image_bytes, refs_dir, data_url, "ref", idx, content_type)
     except (ValueError, binascii.Error, OSError):
         return ""
 

--- a/pages/插件配置/app.js
+++ b/pages/插件配置/app.js
@@ -34,7 +34,7 @@ const mockConfig = {
     },
     optimizer_config: {
         enable_optimizer: true,
-        optimizer_style: "自拍专用极致真实",
+        optimizer_style: "手机日常原生感",
         chain_optimizer: "node_1",
         optimizer_model: "gpt-4o-mini",
         optimizer_timeout: 15,
@@ -111,6 +111,7 @@ let state = {
 
 let initialized = false;
 let savedSnapshot = "";
+let dirtyState = false;
 
 function escapeHtml(value) {
     return String(value ?? "").replace(/[&<>"']/g, (char) => ({
@@ -435,7 +436,8 @@ function showToast(message, type = "success") {
 
 function setDirty(force) {
     if (!initialized) return;
-    const isDirty = typeof force === "boolean" ? force : JSON.stringify(buildPayload()) !== savedSnapshot;
+    dirtyState = typeof force === "boolean" ? force : true;
+    const isDirty = dirtyState;
     document.body.classList.toggle("is-dirty", isDirty);
     const saveState = byId("save-state");
     if (saveState) saveState.textContent = isDirty ? "有未保存更改" : "配置已同步";

--- a/providers/base.py
+++ b/providers/base.py
@@ -3,28 +3,80 @@ import aiohttp
 import base64
 import mimetypes
 import os
+import threading
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional, List
 from astrbot.api import logger
 from ..models import ProviderConfig
 
-class BaseProvider(ABC):
-    # 使用类变量或实例变量存储每个节点的轮询位置
-    _key_indices: Dict[str, int] = {}
+_KEY_ROTATION_LOCK = threading.Lock()
+_KEY_ROTATION_INDEX: Dict[str, int] = {}
 
+
+def normalize_base_url(base_url: str) -> str:
+    return str(base_url or "").rstrip("/")
+
+
+def build_chat_completions_endpoint(base_url: str) -> str:
+    base_url = normalize_base_url(base_url)
+    if not base_url:
+        return ""
+    return f"{base_url}/chat/completions" if base_url.endswith("/v1") else f"{base_url}/v1/chat/completions"
+
+
+def build_video_generations_endpoint(base_url: str) -> str:
+    base_url = normalize_base_url(base_url)
+    if not base_url:
+        return ""
+    return f"{base_url}/videos/generations"
+
+
+def next_api_key(provider_id: str, api_keys: List[str]) -> str:
+    keys = [str(key).strip() for key in api_keys if str(key).strip()]
+    if not provider_id or not keys:
+        return ""
+    with _KEY_ROTATION_LOCK:
+        idx = _KEY_ROTATION_INDEX.get(provider_id, 0)
+        key = keys[idx % len(keys)]
+        _KEY_ROTATION_INDEX[provider_id] = (idx + 1) % len(keys)
+        return key
+
+
+def guess_image_content_type(image_path_or_url: str, content_type: str = "", fallback: str = "image/png") -> str:
+    media_type = str(content_type or "").strip().split(";", 1)[0].strip()
+    if media_type.startswith("image/"):
+        return media_type
+    source = str(image_path_or_url or "")
+    lowered = source.lower()
+    if lowered.startswith("data:"):
+        header = source.split(",", 1)[0]
+        media_type = header[5:].split(";", 1)[0].strip()
+        if media_type.startswith("image/"):
+            return media_type
+    if lowered.endswith(".jpg") or lowered.endswith(".jpeg"):
+        return "image/jpeg"
+    if lowered.endswith(".webp"):
+        return "image/webp"
+    if lowered.endswith(".gif"):
+        return "image/gif"
+    if lowered.endswith(".avif"):
+        return "image/avif"
+    if lowered.endswith(".bmp"):
+        return "image/bmp"
+    if lowered.endswith(".tif") or lowered.endswith(".tiff"):
+        return "image/tiff"
+    guessed = mimetypes.guess_type(source)[0] or ""
+    return guessed if guessed.startswith("image/") else fallback
+
+
+class BaseProvider(ABC):
     def __init__(self, config: ProviderConfig, session: aiohttp.ClientSession):
         self.config = config
         self.session = session
-        if self.config.id not in BaseProvider._key_indices:
-            BaseProvider._key_indices[self.config.id] = 0
+        self._api_keys = [str(key).strip() for key in self.config.api_keys if str(key).strip()]
 
     def get_current_key(self) -> str:
-        if not self.config.api_keys:
-            return ""
-        idx = BaseProvider._key_indices[self.config.id]
-        key = self.config.api_keys[idx % len(self.config.api_keys)]
-        BaseProvider._key_indices[self.config.id] = (idx + 1) % len(self.config.api_keys)
-        return key
+        return next_api_key(self.config.id, self._api_keys)
 
     def encode_local_image_to_base64(self, image_path: str) -> Optional[str]:
         """将本地图片文件转为 API 兼容的 Base64 字符串"""
@@ -35,7 +87,7 @@ class BaseProvider(ABC):
         try:
             with open(image_path, "rb") as image_file:
                 encoded_string = base64.b64encode(image_file.read()).decode('utf-8')
-                mime_type = mimetypes.guess_type(image_path)[0] or "image/png"
+                mime_type = guess_image_content_type(image_path)
                 return f"data:{mime_type};base64,{encoded_string}"
         except Exception as e:
             logger.error(f"❌ 读取本地图片失败: {e}")

--- a/providers/openai_chat_impl.py
+++ b/providers/openai_chat_impl.py
@@ -6,11 +6,10 @@ import aiohttp
 import re
 import json
 import base64
-import mimetypes
 from typing import Any
 from astrbot.api import logger
 
-from .base import BaseProvider
+from .base import BaseProvider, build_chat_completions_endpoint, guess_image_content_type
 
 class OpenAIChatProvider(BaseProvider):
 
@@ -25,16 +24,14 @@ class OpenAIChatProvider(BaseProvider):
                 async with self.session.get(image_path_or_url, headers=headers) as resp:
                     if resp.status == 200:
                         image_bytes = await resp.read()
-                        mime_type = resp.headers.get("Content-Type", "image/png").split(";", 1)[0]
-                        if not mime_type.startswith("image/"):
-                            mime_type = "image/png"
+                        mime_type = guess_image_content_type(image_path_or_url, resp.headers.get("Content-Type", "image/png"))
                         return f"data:{mime_type};base64," + base64.b64encode(image_bytes).decode('utf-8')
                     else:
                         logger.error(f"下载网络图片失败，状态码: {resp.status}")
                         return ""
             else:
                 with open(image_path_or_url, "rb") as f:
-                    mime_type = mimetypes.guess_type(image_path_or_url)[0] or "image/png"
+                    mime_type = guess_image_content_type(image_path_or_url)
                     return f"data:{mime_type};base64," + base64.b64encode(f.read()).decode('utf-8')
         except Exception as e:
             logger.error("读取或下载参考图失败: " + str(e))
@@ -107,8 +104,7 @@ class OpenAIChatProvider(BaseProvider):
             "Authorization": "Bearer " + current_key
         }
         
-        base_url = self.config.base_url.rstrip("/")
-        url = base_url + "/v1/chat/completions" if not base_url.endswith("/v1") else base_url + "/chat/completions"
+        url = build_chat_completions_endpoint(self.config.base_url)
         
         timeout_obj = aiohttp.ClientTimeout(total=self.config.timeout)
         async with self.session.post(url, json=payload, headers=headers, timeout=timeout_obj) as response:

--- a/providers/openai_impl.py
+++ b/providers/openai_impl.py
@@ -1,11 +1,10 @@
 import aiohttp
 import base64
 import json
-import mimetypes
 from typing import Any
 from astrbot.api import logger
 
-from .base import BaseProvider
+from .base import BaseProvider, guess_image_content_type, normalize_base_url
 
 class OpenAIProvider(BaseProvider):
 
@@ -31,14 +30,10 @@ class OpenAIProvider(BaseProvider):
                 return f.read()
 
     def _content_type(self, image_path_or_url: str) -> str:
-        if image_path_or_url.startswith("data:image/jpeg") or image_path_or_url.lower().endswith((".jpg", ".jpeg")):
-            return "image/jpeg"
-        if image_path_or_url.startswith("data:image/webp") or image_path_or_url.lower().endswith(".webp"):
-            return "image/webp"
-        return mimetypes.guess_type(image_path_or_url)[0] or "image/png"
+        return guess_image_content_type(image_path_or_url)
 
     def _base_without_v1(self, base_url: str) -> str:
-        base_url = base_url.rstrip("/")
+        base_url = normalize_base_url(base_url)
         return base_url[:-3] if base_url.endswith("/v1") else base_url
 
     async def generate_image(self, prompt: str, **kwargs: Any) -> str:
@@ -46,7 +41,7 @@ class OpenAIProvider(BaseProvider):
         if not current_key:
             raise ValueError("节点未配置 API Key！")
 
-        base_url = self.config.base_url.rstrip("/")
+        base_url = normalize_base_url(self.config.base_url)
         ref_images = self.get_reference_images(**kwargs)
 
         logger.info(f"📝 [标准通道] 最终发送给 API 的核心提示词:\n{prompt}")

--- a/utils.py
+++ b/utils.py
@@ -1,12 +1,96 @@
 """通用工具函数。"""
 
 import asyncio
+import base64
 import functools
-from typing import Callable, Any, AsyncGenerator
+import mimetypes
+import os
+import time
+import uuid
+from typing import Callable, Any, AsyncGenerator, Tuple
 
 from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent
 from .constants import MessageEmoji
+
+
+def split_data_url(data_url: str) -> Tuple[bytes, str]:
+    """Decode a data URL and return raw bytes plus the media type."""
+    header, base64_str = str(data_url or "").split(",", 1)
+    content_type = ""
+    if header.startswith("data:"):
+        content_type = header[5:].split(";", 1)[0].strip()
+    return base64.b64decode(base64_str, validate=False), content_type
+
+
+def guess_image_content_type(source: str, content_type: str = "", fallback: str = "image/png") -> str:
+    media_type = str(content_type or "").strip().split(";", 1)[0].strip()
+    if media_type.startswith("image/"):
+        return media_type
+    source = str(source or "")
+    lowered = source.lower()
+    if lowered.startswith("data:"):
+        header = source.split(",", 1)[0]
+        media_type = header[5:].split(";", 1)[0].strip()
+        if media_type.startswith("image/"):
+            return media_type
+    if lowered.endswith(".jpg") or lowered.endswith(".jpeg"):
+        return "image/jpeg"
+    if lowered.endswith(".webp"):
+        return "image/webp"
+    if lowered.endswith(".gif"):
+        return "image/gif"
+    if lowered.endswith(".avif"):
+        return "image/avif"
+    if lowered.endswith(".bmp"):
+        return "image/bmp"
+    if lowered.endswith(".tif") or lowered.endswith(".tiff"):
+        return "image/tiff"
+    guessed = mimetypes.guess_type(source)[0] or ""
+    return guessed if guessed.startswith("image/") else fallback
+
+
+def guess_image_extension(source: str, content_type: str = "", fallback: str = "png") -> str:
+    media_type = str(content_type or "").strip().split(";", 1)[0].strip()
+    if not media_type:
+        media_type = guess_image_content_type(source)
+    extension = mimetypes.guess_extension(media_type, strict=False) if media_type else ""
+    if extension:
+        return extension.lstrip(".")
+    lowered = str(source or "").lower()
+    if lowered.startswith("data:"):
+        header = lowered.split(",", 1)[0]
+        if "jpeg" in header or "jpg" in header:
+            return "jpg"
+        if "webp" in header:
+            return "webp"
+        if "gif" in header:
+            return "gif"
+        if "avif" in header:
+            return "avif"
+        if "tiff" in header or "tif" in header:
+            return "tiff"
+    for candidate in ("jpg", "jpeg", "png", "webp", "gif", "avif", "bmp", "tiff"):
+        if lowered.endswith(f".{candidate}"):
+            return candidate
+    return fallback
+
+
+def save_image_bytes(
+    image_bytes: bytes,
+    directory: str,
+    source: str,
+    prefix: str = "ref",
+    index: int = 0,
+    content_type: str = "",
+) -> str:
+    os.makedirs(directory, exist_ok=True)
+    ext = guess_image_extension(source, content_type)
+    filename = f"{prefix}_{int(time.time() * 1000)}_{index}_{uuid.uuid4().hex[:8]}.{ext}"
+    filepath = os.path.abspath(os.path.join(directory, filename))
+    with open(filepath, "wb") as file:
+        file.write(image_bytes)
+    return filepath
 
 def handle_errors(func: Callable) -> Callable:
     """统一错误处理装饰器"""


### PR DESCRIPTION
﻿## What changed
- Split and stabilized the main draw/selfie/video flows around shared helpers and session reuse.
- Unified provider endpoint, API key rotation, and image MIME/extension handling.
- Tightened config/usage persistence and WebUI dirty-state handling.

## Why
- Reduce drift between config sources and provider implementations.
- Avoid blocking I/O and inconsistent fallback behavior as the plugin grows.
- Keep existing AstrBot commands, Web API shapes, and legacy config compatibility intact.

## Validation
- `python -m compileall .`
- `git diff --check`

## Notes
- Real AstrBot runtime smoke test was not available in this shell.
