### PR TITLE
fix: 修复硅基流动 Qwen Image Edit 改图 404/500 报错，支持填写完整接口路径

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.py text eol=lf

--- a/core/video_manager.py
+++ b/core/video_manager.py
@@ -87,8 +87,8 @@ class VideoManager:
         return f"HTTP {response.status}: {text[:1000]}"
 
     async def _poll_task_result(self, provider: ProviderConfig, task_id: str, session: aiohttp.ClientSession) -> str:
-        base_url = provider.base_url.rstrip("/")
-        poll_url = f"{base_url}/videos/generations/{task_id}"
+        endpoint = build_video_generations_endpoint(provider.base_url)
+        poll_url = f"{endpoint}/{task_id}"
         headers = {
             "Authorization": f"Bearer {self._get_api_key(provider)}",
             "Content-Type": "application/json",

--- a/providers/base.py
+++ b/providers/base.py
@@ -17,17 +17,44 @@ def normalize_base_url(base_url: str) -> str:
     return str(base_url or "").rstrip("/")
 
 
+def _has_endpoint_path(base_url: str, endpoint_suffixes: List[str]) -> bool:
+    lowered = base_url.lower()
+    return any(lowered.endswith(suffix) for suffix in endpoint_suffixes)
+
+
 def build_chat_completions_endpoint(base_url: str) -> str:
     base_url = normalize_base_url(base_url)
     if not base_url:
         return ""
+    if _has_endpoint_path(base_url, ["/chat/completions", "/responses"]):
+        return base_url
     return f"{base_url}/chat/completions" if base_url.endswith("/v1") else f"{base_url}/v1/chat/completions"
+
+
+def build_image_generations_endpoint(base_url: str) -> str:
+    base_url = normalize_base_url(base_url)
+    if not base_url:
+        return ""
+    if _has_endpoint_path(base_url, ["/images/generations", "/images/edits"]):
+        return base_url
+    return f"{base_url}/images/generations"
+
+
+def build_image_edits_endpoint(base_url: str) -> str:
+    base_url = normalize_base_url(base_url)
+    if not base_url:
+        return ""
+    if _has_endpoint_path(base_url, ["/images/generations", "/images/edits"]):
+        return base_url
+    return f"{base_url}/images/edits"
 
 
 def build_video_generations_endpoint(base_url: str) -> str:
     base_url = normalize_base_url(base_url)
     if not base_url:
         return ""
+    if _has_endpoint_path(base_url, ["/videos/generations"]):
+        return base_url
     return f"{base_url}/videos/generations"
 
 

--- a/providers/base.py
+++ b/providers/base.py
@@ -5,7 +5,7 @@ import mimetypes
 import os
 import threading
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Optional, List
+from typing import Any, Dict, Iterable, Optional, List
 from astrbot.api import logger
 from ..models import ProviderConfig
 
@@ -17,13 +17,29 @@ def normalize_base_url(base_url: str) -> str:
     return str(base_url or "").rstrip("/")
 
 
-def _has_endpoint_path(base_url: str, endpoint_suffixes: List[str]) -> bool:
+def _has_endpoint_path(base_url: str, endpoint_suffixes: Iterable[str]) -> bool:
     lowered = base_url.lower()
     return any(lowered.endswith(suffix) for suffix in endpoint_suffixes)
 
 
 def _replace_endpoint_path(base_url: str, endpoint_suffix: str, replacement_suffix: str) -> str:
-    return base_url[: -len(endpoint_suffix)] + replacement_suffix
+    if base_url.lower().endswith(endpoint_suffix):
+        return base_url[: -len(endpoint_suffix)] + replacement_suffix
+    return base_url
+
+
+def strip_known_endpoint_path(base_url: str) -> str:
+    base_url = normalize_base_url(base_url)
+    for suffix in (
+        "/chat/completions",
+        "/responses",
+        "/images/generations",
+        "/images/edits",
+        "/videos/generations",
+    ):
+        if base_url.lower().endswith(suffix):
+            return base_url[: -len(suffix)]
+    return base_url
 
 
 def build_chat_completions_endpoint(base_url: str) -> str:
@@ -32,8 +48,9 @@ def build_chat_completions_endpoint(base_url: str) -> str:
         return ""
     if _has_endpoint_path(base_url, ["/chat/completions"]):
         return base_url
-    if _has_endpoint_path(base_url, ["/responses"]):
-        return _replace_endpoint_path(base_url, "/responses", "/chat/completions")
+    base_url = _replace_endpoint_path(base_url, "/responses", "/chat/completions")
+    if _has_endpoint_path(base_url, ["/chat/completions"]):
+        return base_url
     return f"{base_url}/chat/completions" if base_url.endswith("/v1") else f"{base_url}/v1/chat/completions"
 
 
@@ -43,8 +60,9 @@ def build_image_generations_endpoint(base_url: str) -> str:
         return ""
     if _has_endpoint_path(base_url, ["/images/generations"]):
         return base_url
-    if _has_endpoint_path(base_url, ["/images/edits"]):
-        return _replace_endpoint_path(base_url, "/images/edits", "/images/generations")
+    base_url = _replace_endpoint_path(base_url, "/images/edits", "/images/generations")
+    if _has_endpoint_path(base_url, ["/images/generations"]):
+        return base_url
     return f"{base_url}/images/generations"
 
 

--- a/providers/base.py
+++ b/providers/base.py
@@ -22,12 +22,18 @@ def _has_endpoint_path(base_url: str, endpoint_suffixes: List[str]) -> bool:
     return any(lowered.endswith(suffix) for suffix in endpoint_suffixes)
 
 
+def _replace_endpoint_path(base_url: str, endpoint_suffix: str, replacement_suffix: str) -> str:
+    return base_url[: -len(endpoint_suffix)] + replacement_suffix
+
+
 def build_chat_completions_endpoint(base_url: str) -> str:
     base_url = normalize_base_url(base_url)
     if not base_url:
         return ""
-    if _has_endpoint_path(base_url, ["/chat/completions", "/responses"]):
+    if _has_endpoint_path(base_url, ["/chat/completions"]):
         return base_url
+    if _has_endpoint_path(base_url, ["/responses"]):
+        return _replace_endpoint_path(base_url, "/responses", "/chat/completions")
     return f"{base_url}/chat/completions" if base_url.endswith("/v1") else f"{base_url}/v1/chat/completions"
 
 
@@ -35,8 +41,10 @@ def build_image_generations_endpoint(base_url: str) -> str:
     base_url = normalize_base_url(base_url)
     if not base_url:
         return ""
-    if _has_endpoint_path(base_url, ["/images/generations", "/images/edits"]):
+    if _has_endpoint_path(base_url, ["/images/generations"]):
         return base_url
+    if _has_endpoint_path(base_url, ["/images/edits"]):
+        return _replace_endpoint_path(base_url, "/images/edits", "/images/generations")
     return f"{base_url}/images/generations"
 
 
@@ -109,7 +117,7 @@ class BaseProvider(ABC):
         """将本地图片文件转为 API 兼容的 Base64 字符串"""
         if not image_path or not os.path.exists(image_path):
             return None
-        
+
         logger.info(f"[{self.config.id}] 正在将本地参考图转为 Base64: {image_path}")
         try:
             with open(image_path, "rb") as image_file:

--- a/providers/openai_impl.py
+++ b/providers/openai_impl.py
@@ -2,9 +2,17 @@ import aiohttp
 import base64
 import json
 from typing import Any
+from urllib.parse import urljoin
+
 from astrbot.api import logger
 
-from .base import BaseProvider, build_image_edits_endpoint, build_image_generations_endpoint, guess_image_content_type, normalize_base_url
+from .base import (
+    BaseProvider,
+    build_image_edits_endpoint,
+    build_image_generations_endpoint,
+    guess_image_content_type,
+    strip_known_endpoint_path,
+)
 
 class OpenAIProvider(BaseProvider):
 
@@ -37,34 +45,21 @@ class OpenAIProvider(BaseProvider):
         mime_type = self._content_type(image_path_or_url)
         return f"data:{mime_type};base64," + base64.b64encode(image_bytes).decode("utf-8")
 
-    def _api_root_url(self, base_url: str) -> str:
-        base_url = normalize_base_url(base_url)
-        lowered = base_url.lower()
-        endpoint_suffixes = (
-            "/images/generations",
-            "/images/edits",
-            "/chat/completions",
-            "/videos/generations",
-        )
-        for suffix in endpoint_suffixes:
-            if lowered.endswith(suffix):
-                return base_url[: -len(suffix)]
-        return base_url
+    def _response_base_url(self, base_url: str) -> str:
+        api_root = strip_known_endpoint_path(base_url)
+        return api_root[:-3] if api_root.endswith("/v1") else api_root
 
-    def _resolve_image_url(self, image_url: str, base_url: str) -> str:
-        image_url = str(image_url or "")
-        if image_url.startswith("http") or image_url.startswith("data:"):
-            return image_url
-        clean_base = self._api_root_url(base_url).rstrip("/")
-        clean_url = image_url.lstrip("/")
-        return clean_base + "/" + clean_url
+    def _resolve_image_url(self, img_url: str, base_url: str) -> str:
+        if img_url.startswith("http") or img_url.startswith("data:"):
+            return img_url
+        return urljoin(self._response_base_url(base_url).rstrip("/") + "/", img_url.lstrip("/"))
 
     async def generate_image(self, prompt: str, **kwargs: Any) -> str:
         current_key = self.get_current_key()
         if not current_key:
             raise ValueError("节点未配置 API Key！")
 
-        base_url = normalize_base_url(self.config.base_url)
+        base_url = self.config.base_url
         ref_images = self.get_reference_images(**kwargs)
 
         logger.info(f"📝 [标准通道] 最终发送给 API 的核心提示词:\n{prompt}")
@@ -90,7 +85,8 @@ class OpenAIProvider(BaseProvider):
                         raise RuntimeError(f"读取第 {idx} 张参考图数据失败: {e}")
                     payload["image" if idx == 1 else f"image{idx}"] = image_value
                 payload.update(api_kwargs)
-                logger.info(f"📤 [标准通道] 附带高级参数的请求体:\n{json.dumps({k: v for k, v in payload.items() if not str(k).startswith('image')}, ensure_ascii=False)}")
+                log_payload = {k: v for k, v in payload.items() if not str(k).startswith("image")}
+                logger.info(f"📤 [标准通道] 附带高级参数的请求体:\n{json.dumps(log_payload, ensure_ascii=False)}")
                 headers = {"Content-Type": "application/json", "Authorization": "Bearer " + current_key}
                 timeout_obj = aiohttp.ClientTimeout(total=self.config.timeout)
                 async with self.session.post(url, json=payload, headers=headers, timeout=timeout_obj) as response:
@@ -166,16 +162,15 @@ class OpenAIProvider(BaseProvider):
             if "b64_json" in data_item:
                 return "data:image/png;base64," + data_item["b64_json"]
             if "url" in data_item:
-                return self._resolve_image_url(data_item["url"], base_url)
+                return self._resolve_image_url(str(data_item["url"]), base_url)
 
-        if "images" in result and len(result["images"]) > 0:
+        if "images" in result and isinstance(result["images"], list) and result["images"]:
             image_item = result["images"][0]
+            if isinstance(image_item, dict) and "url" in image_item:
+                return self._resolve_image_url(str(image_item["url"]), base_url)
+            if isinstance(image_item, dict) and "b64_json" in image_item:
+                return "data:image/png;base64," + image_item["b64_json"]
             if isinstance(image_item, str):
                 return self._resolve_image_url(image_item, base_url)
-            if isinstance(image_item, dict):
-                if "b64_json" in image_item:
-                    return "data:image/png;base64," + image_item["b64_json"]
-                if "url" in image_item:
-                    return self._resolve_image_url(image_item["url"], base_url)
 
         raise ValueError("API 返回结构异常，未找到图片数据: " + str(result))

--- a/providers/openai_impl.py
+++ b/providers/openai_impl.py
@@ -37,9 +37,27 @@ class OpenAIProvider(BaseProvider):
         mime_type = self._content_type(image_path_or_url)
         return f"data:{mime_type};base64," + base64.b64encode(image_bytes).decode("utf-8")
 
-    def _base_without_v1(self, base_url: str) -> str:
+    def _api_root_url(self, base_url: str) -> str:
         base_url = normalize_base_url(base_url)
-        return base_url[:-3] if base_url.endswith("/v1") else base_url
+        lowered = base_url.lower()
+        endpoint_suffixes = (
+            "/images/generations",
+            "/images/edits",
+            "/chat/completions",
+            "/videos/generations",
+        )
+        for suffix in endpoint_suffixes:
+            if lowered.endswith(suffix):
+                return base_url[: -len(suffix)]
+        return base_url
+
+    def _resolve_image_url(self, image_url: str, base_url: str) -> str:
+        image_url = str(image_url or "")
+        if image_url.startswith("http") or image_url.startswith("data:"):
+            return image_url
+        clean_base = self._api_root_url(base_url).rstrip("/")
+        clean_url = image_url.lstrip("/")
+        return clean_base + "/" + clean_url
 
     async def generate_image(self, prompt: str, **kwargs: Any) -> str:
         current_key = self.get_current_key()
@@ -94,34 +112,34 @@ class OpenAIProvider(BaseProvider):
             data.add_field('prompt', prompt)
             data.add_field('model', self.config.model)
             data.add_field('n', '1')
-            
+
             # 高级参数注入表单
             for k, v in api_kwargs.items():
                 data.add_field(k, str(v))
-            
+
             headers = {"Authorization": "Bearer " + current_key}
             timeout_obj = aiohttp.ClientTimeout(total=self.config.timeout)
             async with self.session.post(url, data=data, headers=headers, timeout=timeout_obj) as response:
                 return await self._parse_response(response, base_url)
-                
+
         else:
             url = build_image_generations_endpoint(base_url)
-            
+
             # 基础 Payload
             payload = {
-                "model": self.config.model, 
-                "prompt": prompt, 
+                "model": self.config.model,
+                "prompt": prompt,
                 "n": 1
             }
-            
+
             # 🚀 完美兼容 gptimage2 / gemini-3.1-image 规范
             # 暴力将所有高级参数塞入 JSON 的最外层，中转 API 会直接识别并调用底层
             payload.update(api_kwargs)
-            
+
             logger.info(f"📤 [标准通道] 附带高级参数的请求体:\n{json.dumps(payload, ensure_ascii=False)}")
-            
+
             headers = {"Content-Type": "application/json", "Authorization": "Bearer " + current_key}
-            
+
             timeout_obj = aiohttp.ClientTimeout(total=self.config.timeout)
             async with self.session.post(url, json=payload, headers=headers, timeout=timeout_obj) as response:
                 return await self._parse_response(response, base_url)
@@ -138,21 +156,26 @@ class OpenAIProvider(BaseProvider):
                     error_msg = error_json["error"]["message"]
             except Exception:
                 pass
-                
+
             raise RuntimeError("HTTP " + str(status) + ": " + error_msg)
-        
+
         result = await response.json()
-        
+
         if "data" in result and len(result["data"]) > 0:
             data_item = result["data"][0]
             if "b64_json" in data_item:
                 return "data:image/png;base64," + data_item["b64_json"]
             if "url" in data_item:
-                img_url = data_item["url"]
-                if not img_url.startswith("http") and not img_url.startswith("data:"):
-                    clean_base = self._base_without_v1(base_url)
-                    clean_url = img_url.lstrip("/")
-                    img_url = clean_base + "/" + clean_url
-                return img_url
-                
+                return self._resolve_image_url(data_item["url"], base_url)
+
+        if "images" in result and len(result["images"]) > 0:
+            image_item = result["images"][0]
+            if isinstance(image_item, str):
+                return self._resolve_image_url(image_item, base_url)
+            if isinstance(image_item, dict):
+                if "b64_json" in image_item:
+                    return "data:image/png;base64," + image_item["b64_json"]
+                if "url" in image_item:
+                    return self._resolve_image_url(image_item["url"], base_url)
+
         raise ValueError("API 返回结构异常，未找到图片数据: " + str(result))

--- a/providers/openai_impl.py
+++ b/providers/openai_impl.py
@@ -4,7 +4,7 @@ import json
 from typing import Any
 from astrbot.api import logger
 
-from .base import BaseProvider, guess_image_content_type, normalize_base_url
+from .base import BaseProvider, build_image_edits_endpoint, build_image_generations_endpoint, guess_image_content_type, normalize_base_url
 
 class OpenAIProvider(BaseProvider):
 
@@ -32,6 +32,11 @@ class OpenAIProvider(BaseProvider):
     def _content_type(self, image_path_or_url: str) -> str:
         return guess_image_content_type(image_path_or_url)
 
+    async def _encode_image_to_data_url(self, image_path_or_url: str) -> str:
+        image_bytes = await self._get_image_bytes(image_path_or_url)
+        mime_type = self._content_type(image_path_or_url)
+        return f"data:{mime_type};base64," + base64.b64encode(image_bytes).decode("utf-8")
+
     def _base_without_v1(self, base_url: str) -> str:
         base_url = normalize_base_url(base_url)
         return base_url[:-3] if base_url.endswith("/v1") else base_url
@@ -51,8 +56,27 @@ class OpenAIProvider(BaseProvider):
         api_kwargs = {k: v for k, v in kwargs.items() if k not in internal_keys}
 
         if ref_images:
-            url = base_url + "/images/edits"
+            url = build_image_edits_endpoint(base_url)
             logger.info(f"✅ 检测到 {len(ref_images)} 张参考图，正切换至标准改图通道: {url}")
+
+            if url.lower().endswith("/images/generations"):
+                payload = {
+                    "model": self.config.model,
+                    "prompt": prompt,
+                    "n": 1,
+                }
+                for idx, ref_image in enumerate(ref_images[:3], start=1):
+                    try:
+                        image_value = await self._encode_image_to_data_url(ref_image)
+                    except Exception as e:
+                        raise RuntimeError(f"读取第 {idx} 张参考图数据失败: {e}")
+                    payload["image" if idx == 1 else f"image{idx}"] = image_value
+                payload.update(api_kwargs)
+                logger.info(f"📤 [标准通道] 附带高级参数的请求体:\n{json.dumps({k: v for k, v in payload.items() if not str(k).startswith('image')}, ensure_ascii=False)}")
+                headers = {"Content-Type": "application/json", "Authorization": "Bearer " + current_key}
+                timeout_obj = aiohttp.ClientTimeout(total=self.config.timeout)
+                async with self.session.post(url, json=payload, headers=headers, timeout=timeout_obj) as response:
+                    return await self._parse_response(response, base_url)
 
             data = aiohttp.FormData()
             for idx, ref_image in enumerate(ref_images, start=1):
@@ -81,7 +105,7 @@ class OpenAIProvider(BaseProvider):
                 return await self._parse_response(response, base_url)
                 
         else:
-            url = base_url + "/images/generations"
+            url = build_image_generations_endpoint(base_url)
             
             # 基础 Payload
             payload = {


### PR DESCRIPTION
### 问题描述

使用硅基流动（SiliconFlow）的 `Qwen/Qwen-Image-Edit-2509` 模型进行图生图时：
1. 插件默认将有参考图的请求切换到 `/images/edits` 接口，但硅基流动不支持该路径，返回 `404 page not found`。
2. 即使手动将完整路径填为 `/v1/images/generations`，插件仍会继续追加 `/images/edits` 后缀，导致路径被错误拼接。
3. 硅基流动的 `/images/generations` 接口要求通过 JSON 的 `image` 字段传递参考图，而非 OpenAI 标准的 `multipart/form-data` 格式，导致 `HTTP 500` 错误。

### 修复方案

#### 1. `providers/base.py`

- 新增 `_has_endpoint_path()` 工具函数，检测用户填写的 `base_url` 是否已经是完整的接口路径。
- 新增 `build_image_generations_endpoint()` 和 `build_image_edits_endpoint()` 函数，统一管理图片通道的 URL 构建。
- 为 `build_chat_completions_endpoint()` 和 `build_video_generations_endpoint()` 也增加完整路径识别，避免路径被重复拼接。

#### 2. `providers/openai_impl.py`

- 新增 `_encode_image_to_data_url()` 方法，将参考图转为 `data:image/...;base64,...` 格式。
- 当有参考图且最终地址以 `/images/generations` 结尾时，使用 JSON 格式（`image`/`image2`/`image3` 字段）发送请求，适配硅基流动接口。
- 当最终地址为 `/images/edits` 时，保持 OpenAI 标准 `multipart/form-data` 格式不变。

### 服务商填写方式

| 服务商 | 接口地址 |
|---|---|
| OpenAI / 标准兼容服务 | `https://api.openai.com/v1` |
| 硅基流动 Qwen Image Edit | `https://api.siliconflow.cn/v1/images/generations` |

### 向后兼容

- 填写基础地址的行为与原有逻辑完全一致，不受影响。
- 原版 OpenAI 的文生图和改图流程均保持不变。