### PR TITLE
[codex] fix image endpoint compatibility

### DIFF
--- a/core/video_manager.py
+++ b/core/video_manager.py
@@ -87,8 +87,8 @@ class VideoManager:
         return f"HTTP {response.status}: {text[:1000]}"
 
     async def _poll_task_result(self, provider: ProviderConfig, task_id: str, session: aiohttp.ClientSession) -> str:
-        base_url = provider.base_url.rstrip("/")
-        poll_url = f"{base_url}/videos/generations/{task_id}"
+        endpoint = build_video_generations_endpoint(provider.base_url)
+        poll_url = f"{endpoint}/{task_id}"
         headers = {
             "Authorization": f"Bearer {self._get_api_key(provider)}",
             "Content-Type": "application/json",

--- a/providers/base.py
+++ b/providers/base.py
@@ -5,7 +5,7 @@ import mimetypes
 import os
 import threading
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Optional, List
+from typing import Any, Dict, Iterable, Optional, List
 from astrbot.api import logger
 from ..models import ProviderConfig
 
@@ -17,17 +17,70 @@ def normalize_base_url(base_url: str) -> str:
     return str(base_url or "").rstrip("/")
 
 
+def _has_endpoint_path(base_url: str, endpoint_suffixes: Iterable[str]) -> bool:
+    lowered = base_url.lower()
+    return any(lowered.endswith(suffix) for suffix in endpoint_suffixes)
+
+
+def _replace_endpoint_path(base_url: str, endpoint_suffix: str, replacement_suffix: str) -> str:
+    if base_url.lower().endswith(endpoint_suffix):
+        return base_url[: -len(endpoint_suffix)] + replacement_suffix
+    return base_url
+
+
+def strip_known_endpoint_path(base_url: str) -> str:
+    base_url = normalize_base_url(base_url)
+    for suffix in (
+        "/chat/completions",
+        "/responses",
+        "/images/generations",
+        "/images/edits",
+        "/videos/generations",
+    ):
+        if base_url.lower().endswith(suffix):
+            return base_url[: -len(suffix)]
+    return base_url
+
+
 def build_chat_completions_endpoint(base_url: str) -> str:
     base_url = normalize_base_url(base_url)
     if not base_url:
         return ""
+    if _has_endpoint_path(base_url, ["/chat/completions"]):
+        return base_url
+    base_url = _replace_endpoint_path(base_url, "/responses", "/chat/completions")
+    if _has_endpoint_path(base_url, ["/chat/completions"]):
+        return base_url
     return f"{base_url}/chat/completions" if base_url.endswith("/v1") else f"{base_url}/v1/chat/completions"
+
+
+def build_image_generations_endpoint(base_url: str) -> str:
+    base_url = normalize_base_url(base_url)
+    if not base_url:
+        return ""
+    if _has_endpoint_path(base_url, ["/images/generations"]):
+        return base_url
+    base_url = _replace_endpoint_path(base_url, "/images/edits", "/images/generations")
+    if _has_endpoint_path(base_url, ["/images/generations"]):
+        return base_url
+    return f"{base_url}/images/generations"
+
+
+def build_image_edits_endpoint(base_url: str) -> str:
+    base_url = normalize_base_url(base_url)
+    if not base_url:
+        return ""
+    if _has_endpoint_path(base_url, ["/images/generations", "/images/edits"]):
+        return base_url
+    return f"{base_url}/images/edits"
 
 
 def build_video_generations_endpoint(base_url: str) -> str:
     base_url = normalize_base_url(base_url)
     if not base_url:
         return ""
+    if _has_endpoint_path(base_url, ["/videos/generations"]):
+        return base_url
     return f"{base_url}/videos/generations"
 
 
@@ -82,7 +135,7 @@ class BaseProvider(ABC):
         """将本地图片文件转为 API 兼容的 Base64 字符串"""
         if not image_path or not os.path.exists(image_path):
             return None
-        
+
         logger.info(f"[{self.config.id}] 正在将本地参考图转为 Base64: {image_path}")
         try:
             with open(image_path, "rb") as image_file:

--- a/providers/openai_impl.py
+++ b/providers/openai_impl.py
@@ -2,9 +2,17 @@ import aiohttp
 import base64
 import json
 from typing import Any
+from urllib.parse import urljoin
+
 from astrbot.api import logger
 
-from .base import BaseProvider, guess_image_content_type, normalize_base_url
+from .base import (
+    BaseProvider,
+    build_image_edits_endpoint,
+    build_image_generations_endpoint,
+    guess_image_content_type,
+    strip_known_endpoint_path,
+)
 
 class OpenAIProvider(BaseProvider):
 
@@ -32,16 +40,26 @@ class OpenAIProvider(BaseProvider):
     def _content_type(self, image_path_or_url: str) -> str:
         return guess_image_content_type(image_path_or_url)
 
-    def _base_without_v1(self, base_url: str) -> str:
-        base_url = normalize_base_url(base_url)
-        return base_url[:-3] if base_url.endswith("/v1") else base_url
+    async def _encode_image_to_data_url(self, image_path_or_url: str) -> str:
+        image_bytes = await self._get_image_bytes(image_path_or_url)
+        mime_type = self._content_type(image_path_or_url)
+        return f"data:{mime_type};base64," + base64.b64encode(image_bytes).decode("utf-8")
+
+    def _response_base_url(self, base_url: str) -> str:
+        api_root = strip_known_endpoint_path(base_url)
+        return api_root[:-3] if api_root.endswith("/v1") else api_root
+
+    def _resolve_image_url(self, img_url: str, base_url: str) -> str:
+        if img_url.startswith("http") or img_url.startswith("data:"):
+            return img_url
+        return urljoin(self._response_base_url(base_url).rstrip("/") + "/", img_url.lstrip("/"))
 
     async def generate_image(self, prompt: str, **kwargs: Any) -> str:
         current_key = self.get_current_key()
         if not current_key:
             raise ValueError("节点未配置 API Key！")
 
-        base_url = normalize_base_url(self.config.base_url)
+        base_url = self.config.base_url
         ref_images = self.get_reference_images(**kwargs)
 
         logger.info(f"📝 [标准通道] 最终发送给 API 的核心提示词:\n{prompt}")
@@ -51,8 +69,28 @@ class OpenAIProvider(BaseProvider):
         api_kwargs = {k: v for k, v in kwargs.items() if k not in internal_keys}
 
         if ref_images:
-            url = base_url + "/images/edits"
+            url = build_image_edits_endpoint(base_url)
             logger.info(f"✅ 检测到 {len(ref_images)} 张参考图，正切换至标准改图通道: {url}")
+
+            if url.lower().endswith("/images/generations"):
+                payload = {
+                    "model": self.config.model,
+                    "prompt": prompt,
+                    "n": 1,
+                }
+                for idx, ref_image in enumerate(ref_images[:3], start=1):
+                    try:
+                        image_value = await self._encode_image_to_data_url(ref_image)
+                    except Exception as e:
+                        raise RuntimeError(f"读取第 {idx} 张参考图数据失败: {e}")
+                    payload["image" if idx == 1 else f"image{idx}"] = image_value
+                payload.update(api_kwargs)
+                log_payload = {k: v for k, v in payload.items() if not str(k).startswith("image")}
+                logger.info(f"📤 [标准通道] 附带高级参数的请求体:\n{json.dumps(log_payload, ensure_ascii=False)}")
+                headers = {"Content-Type": "application/json", "Authorization": "Bearer " + current_key}
+                timeout_obj = aiohttp.ClientTimeout(total=self.config.timeout)
+                async with self.session.post(url, json=payload, headers=headers, timeout=timeout_obj) as response:
+                    return await self._parse_response(response, base_url)
 
             data = aiohttp.FormData()
             for idx, ref_image in enumerate(ref_images, start=1):
@@ -81,7 +119,7 @@ class OpenAIProvider(BaseProvider):
                 return await self._parse_response(response, base_url)
                 
         else:
-            url = base_url + "/images/generations"
+            url = build_image_generations_endpoint(base_url)
             
             # 基础 Payload
             payload = {
@@ -124,11 +162,13 @@ class OpenAIProvider(BaseProvider):
             if "b64_json" in data_item:
                 return "data:image/png;base64," + data_item["b64_json"]
             if "url" in data_item:
-                img_url = data_item["url"]
-                if not img_url.startswith("http") and not img_url.startswith("data:"):
-                    clean_base = self._base_without_v1(base_url)
-                    clean_url = img_url.lstrip("/")
-                    img_url = clean_base + "/" + clean_url
-                return img_url
-                
+                return self._resolve_image_url(str(data_item["url"]), base_url)
+
+        if "images" in result and isinstance(result["images"], list) and result["images"]:
+            image_item = result["images"][0]
+            if isinstance(image_item, dict) and "url" in image_item:
+                return self._resolve_image_url(str(image_item["url"]), base_url)
+            if isinstance(image_item, str):
+                return self._resolve_image_url(image_item, base_url)
+
         raise ValueError("API 返回结构异常，未找到图片数据: " + str(result))


### PR DESCRIPTION
﻿## Summary
- keep full endpoint support for image and video providers, but normalize endpoint routing by operation
- support SiliconFlow/Qwen Image Edit JSON requests through `/images/generations`
- parse both OpenAI-style `data` responses and SiliconFlow-style `images` responses
- resolve relative image URLs from the API root instead of appending them to a full endpoint path
- fix async video polling when the configured URL is already `/videos/generations`

## Context
This is a cleaned-up follow-up to #22. The original PR addressed SiliconFlow Qwen Image Edit 404/500 failures, but still had response parsing and endpoint routing edge cases that could break successful requests or pure text-to-image calls.

## Validation
- `git diff --cached --check`
- `git diff --check`
- `python -B -m py_compile providers/base.py providers/openai_impl.py core/video_manager.py`
- local helper assertions for endpoint builders and OpenAI/SiliconFlow response parsing
