### PR TITLE
feat: add custom full endpoint image provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.3.12
+
+- 图像 Provider 新增 `custom_endpoint` 自定义完整路径模式，配置页显示为“自定义”。
+- 自定义模式只请求填写的完整 URL，不再自动追加 `/v1`、`/images/generations`、`/images/edits` 或 `/chat/completions`。
+- 增强图像返回解析，兼容 OpenAI Images、Chat Completions、Responses API 以及常见中转站的 URL/Base64 返回格式。
+
 ## 3.3.11
 
 - 新增“可使用人员白名单”：留空时默认不启用；填写后仅名单内用户可调用插件指令和 LLM 工具。

--- a/README.md
+++ b/README.md
@@ -63,11 +63,13 @@ https://github.com/diaomin66/astrbot_plugin_omnidraw/
 | 字段 | 怎么填 |
 | :--- | :--- |
 | 节点 ID | 自己取一个好记的名字，比如 `image_node_1` |
-| API 类型 | 按你的接口选择，常见是 `openai_chat` 或 `openai_image` |
-| Base URL | 中转站或官方接口地址，例如 `https://example.com/v1` |
+| API 类型 | 按你的接口选择：`openai_image` 标准生图、`openai_chat` 对话透传中转站、`custom_endpoint` 自定义完整路径 |
+| Base URL | 标准/对话模式填中转站或官方接口地址，例如 `https://example.com/v1`；自定义模式必须填完整请求 URL |
 | API Keys | 填你的 key，多个 key 可按页面提示添加 |
 | 模型 | 填模型名，例如 `gpt-image-1`、`gemini-xxx-image` 等 |
 | Timeout | 建议画图 120-300，视频 300 或更高 |
+
+`custom_endpoint` 只请求你填写的完整路径，不会自动追加 `/v1`、`/images/generations`、`/images/edits` 或 `/chat/completions`。例如要请求硅基流动、豆包或海外中转站的某个固定接口时，应直接填写 `https://api.example.com/v1/images/generations`、`https://api.example.com/v1/chat/completions` 或服务商文档给出的完整 endpoint。Chat Completions 仅适合会返回图片链接的中转站；官方 OpenAI 生图建议使用 Images 或 Responses 路径。
 
 然后在“路由 / 链路”里把：
 

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -173,15 +173,16 @@
             "type": "string",
             "options": [
               "openai_image",
-              "openai_chat"
+              "openai_chat",
+              "custom_endpoint"
             ],
-            "hint": "openai_image 适合标准图片接口；openai_chat 适合通过 chat/completions 透传生图的中转站。",
+            "hint": "openai_image 适合标准图片接口；openai_chat 适合会返回图片链接的 chat/completions 中转站；custom_endpoint 为自定义完整路径，只请求你填写的完整 URL，不会追加 /v1、/images/generations 或 /chat/completions。",
             "default": "openai_image"
           },
           "base_url": {
             "description": "接口地址",
             "type": "string",
-            "hint": "通常需要包含 /v1，例如 https://api.example.com/v1。",
+            "hint": "标准/对话模式通常填写 https://api.example.com/v1；自定义模式必须填写完整请求路径，例如 https://api.example.com/v1/images/generations。",
             "default": ""
           },
           "api_keys": {

--- a/constants.py
+++ b/constants.py
@@ -14,6 +14,7 @@ class APIType:
     """接口类型枚举"""
     OPENAI_IMAGE = "openai_image"
     OPENAI_CHAT = "openai_chat"  # 新增 Chat 解析出图类型
+    CUSTOM_ENDPOINT = "custom_endpoint"
 
 class MessageEmoji:
     """消息表情符号"""

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,6 +2,7 @@ name: astrbot_plugin_omnidraw
 display_name: 万象画卷
 desc: 轻快生图插件，文生图、图生图、自拍、视频一站搞定。
 help: 发送 /万象帮助 查看说明
-version: 3.3.11
+version: 3.3.12
 author: 雪碧bir
 repo: https://github.com/diaomin66/astrbot_plugin_omnidraw/
+astrbot_version: ">=4.16,<5"

--- a/models.py
+++ b/models.py
@@ -17,7 +17,7 @@ from .utils import save_image_bytes, split_data_url
 
 PLUGIN_NAME = "astrbot_plugin_omnidraw"
 PLUGIN_AUTHOR = "雪碧bir"
-PLUGIN_VERSION = "3.3.11"
+PLUGIN_VERSION = "3.3.12"
 DEFAULT_CACHE_CLEANUP_INTERVAL_HOURS = 24
 DEFAULT_MAX_CACHE_SIZE_MB = 512
 
@@ -335,6 +335,8 @@ def _normalize_api_type(value: Any, is_video: bool) -> str:
         if "sync" in lowered or "同步" in raw:
             return "openai_sync"
         return "async_task"
+    if lowered in {"custom_endpoint", "custom"} or "自定义" in raw:
+        return "custom_endpoint"
     if "chat" in lowered or "对话" in raw:
         return "openai_chat"
     return "openai_image"

--- a/pages/插件配置/app.js
+++ b/pages/插件配置/app.js
@@ -833,7 +833,8 @@ function renderProviderCard(p, i, isVideo) {
         ]
         : [
             ["openai_image", "标准生图"],
-            ["openai_chat", "对话透传"]
+            ["openai_chat", "对话透传"],
+            ["custom_endpoint", "自定义"]
         ];
 
     const modeChips = modes.map(([value, label]) => {
@@ -968,6 +969,20 @@ function buildPayload() {
     };
 }
 
+function isCompleteCustomEndpoint(value) {
+    try {
+        const url = new URL(String(value || "").trim());
+        if (!["http:", "https:"].includes(url.protocol)) return false;
+        const segments = url.pathname.split("/").filter(Boolean);
+        if (!segments.length) return false;
+        const last = segments[segments.length - 1] || "";
+        if (/^v\d+(beta\d*)?$/i.test(last) || last.toLowerCase() === "api") return false;
+        return true;
+    } catch {
+        return false;
+    }
+}
+
 function validateConfig() {
     const checkinMin = readNonnegativeIntInput("usage_checkin_min", 0);
     const checkinMax = readNonnegativeIntInput("usage_checkin_max", 0);
@@ -981,6 +996,8 @@ function validateConfig() {
         const duplicates = ids.filter((id, idx) => ids.indexOf(id) !== idx);
         if (list.some((node) => !String(node.id || "").trim())) return `${label}存在未填写节点 ID`;
         if (duplicates.length) return `${label}节点 ID 重复：${duplicates[0]}`;
+        const invalidCustom = list.find((node) => node.api_type === "custom_endpoint" && !isCompleteCustomEndpoint(node.base_url));
+        if (invalidCustom) return `${label}自定义节点 ${invalidCustom.id || ""} 必须填写完整 http(s) 请求路径，不能只填域名或 /v1`;
         return "";
     };
     const validateRoute = (routeName, label) => {

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -4,6 +4,7 @@ import aiohttp
 from ..models import ProviderConfig
 from ..constants import APIType
 from .base import BaseProvider
+from .custom_endpoint_impl import CustomEndpointProvider
 from .openai_impl import OpenAIProvider
 from .openai_chat_impl import OpenAIChatProvider
 
@@ -14,5 +15,7 @@ def create_provider(config: ProviderConfig, session: aiohttp.ClientSession) -> B
     # ===== 加入了 openai_chat 的识别分支 =====
     elif config.api_type == APIType.OPENAI_CHAT:
         return OpenAIChatProvider(config, session)
+    elif config.api_type == APIType.CUSTOM_ENDPOINT:
+        return CustomEndpointProvider(config, session)
     else:
         raise NotImplementedError(f"暂不支持该类型的接口: {config.api_type}")

--- a/providers/base.py
+++ b/providers/base.py
@@ -1,11 +1,14 @@
 """图片 Provider 基类。"""
 import aiohttp
 import base64
+import json
 import mimetypes
 import os
+import re
 import threading
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Iterable, Optional, List
+from urllib.parse import urljoin, urlparse
 from astrbot.api import logger
 from ..models import ProviderConfig
 
@@ -15,6 +18,25 @@ _KEY_ROTATION_INDEX: Dict[str, int] = {}
 
 def normalize_base_url(base_url: str) -> str:
     return str(base_url or "").rstrip("/")
+
+
+def is_complete_endpoint_url(base_url: str) -> bool:
+    """Return True only for full URLs that point at a concrete request path."""
+    parsed = urlparse(normalize_base_url(base_url))
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return False
+    path = parsed.path.rstrip("/")
+    if not path:
+        return False
+    segments = [segment for segment in path.split("/") if segment]
+    if not segments:
+        return False
+    version_like = re.compile(r"^v\d+(?:beta\d*)?$", re.IGNORECASE)
+    if len(segments) == 1 and version_like.fullmatch(segments[0]):
+        return False
+    if segments[-1].lower() == "api" or version_like.fullmatch(segments[-1]):
+        return False
+    return True
 
 
 def _has_endpoint_path(base_url: str, endpoint_suffixes: Iterable[str]) -> bool:
@@ -40,6 +62,18 @@ def strip_known_endpoint_path(base_url: str) -> str:
         if base_url.lower().endswith(suffix):
             return base_url[: -len(suffix)]
     return base_url
+
+
+def response_base_url(base_url: str) -> str:
+    api_root = strip_known_endpoint_path(base_url)
+    return api_root[:-3] if api_root.endswith("/v1") else api_root
+
+
+def resolve_response_url(value: str, base_url: str) -> str:
+    image_ref = str(value or "").strip()
+    if image_ref.startswith("http") or image_ref.startswith("data:"):
+        return image_ref
+    return urljoin(response_base_url(base_url).rstrip("/") + "/", image_ref.lstrip("/"))
 
 
 def build_chat_completions_endpoint(base_url: str) -> str:
@@ -120,6 +154,154 @@ def guess_image_content_type(image_path_or_url: str, content_type: str = "", fal
         return "image/tiff"
     guessed = mimetypes.guess_type(source)[0] or ""
     return guessed if guessed.startswith("image/") else fallback
+
+
+def extract_error_message(payload: Any) -> str:
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except Exception:
+            return payload
+
+    if not isinstance(payload, dict):
+        return str(payload)
+
+    error = payload.get("error")
+    if isinstance(error, dict):
+        for key in ("message", "msg", "detail", "error_msg", "code"):
+            if error.get(key):
+                return str(error[key])
+        return str(error)
+    if error:
+        return str(error)
+
+    for key in ("message", "msg", "detail", "error_msg"):
+        if payload.get(key):
+            value = payload[key]
+            if isinstance(value, (dict, list)):
+                return json.dumps(value, ensure_ascii=False)
+            return str(value)
+
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def extract_image_url_from_response(payload: Any, base_url: str) -> str:
+    """Extract an image URL or data URL from common image/chat/responses shapes."""
+
+    def likely_base64(value: str) -> bool:
+        text = value.strip()
+        if len(text) < 80:
+            return False
+        if not re.fullmatch(r"[A-Za-z0-9+/=\s]+", text):
+            return False
+        try:
+            base64.b64decode(text, validate=False)
+            return True
+        except Exception:
+            return False
+
+    def from_text(text: str) -> str:
+        text = str(text or "").strip()
+        if not text:
+            return ""
+        if text.startswith("data:image"):
+            return text
+        if text.startswith("{") or text.startswith("["):
+            try:
+                nested = json.loads(text)
+            except Exception:
+                nested = None
+            if nested is not None:
+                nested_image = walk(nested)
+                if nested_image:
+                    return nested_image
+        markdown_match = re.search(r"!\[[^\]]*\]\((data:image[^)]+|https?://[^)\s]+)\)", text)
+        if markdown_match:
+            return resolve_response_url(markdown_match.group(1), base_url)
+        url_match = re.search(r"(https?://[^\s\]\)\"']+)", text)
+        if url_match:
+            return resolve_response_url(url_match.group(1), base_url)
+        return ""
+
+    def coerce_image_value(value: Any, assume_base64: bool = False) -> str:
+        if isinstance(value, str):
+            text = value.strip()
+            extracted = from_text(text)
+            if extracted:
+                return extracted
+            if assume_base64 and likely_base64(text):
+                return "data:image/png;base64," + re.sub(r"\s+", "", text)
+            return ""
+        return walk(value)
+
+    def walk(value: Any) -> str:
+        if isinstance(value, str):
+            return from_text(value)
+        if isinstance(value, list):
+            for item in value:
+                image = walk(item)
+                if image:
+                    return image
+            return ""
+        if not isinstance(value, dict):
+            return ""
+
+        if value.get("type") == "image_generation_call" and value.get("result"):
+            image = coerce_image_value(value.get("result"), assume_base64=True)
+            if image:
+                return image
+
+        for key in ("b64_json", "base64", "image_base64", "image_data", "binary_data_base64"):
+            if key in value:
+                image = coerce_image_value(value.get(key), assume_base64=True)
+                if image:
+                    return image
+
+        if "image" in value:
+            image_value = value.get("image")
+            image = coerce_image_value(image_value, assume_base64=True)
+            if image:
+                return image
+            if isinstance(image_value, str):
+                text = image_value.strip()
+                if re.search(r"\.(?:png|jpe?g|webp|gif|bmp|avif)(?:[?#].*)?$", text, re.IGNORECASE):
+                    return resolve_response_url(text, base_url)
+
+        for key in ("url", "image_url", "uri"):
+            if key in value:
+                nested = value.get(key)
+                if isinstance(nested, dict) and "url" in nested:
+                    nested = nested.get("url")
+                if isinstance(nested, str) and nested.strip():
+                    image = from_text(nested)
+                    return image or resolve_response_url(nested, base_url)
+                image = coerce_image_value(nested)
+                if image:
+                    return image
+
+        for key in (
+            "data",
+            "images",
+            "image",
+            "output",
+            "output_text",
+            "result",
+            "results",
+            "choices",
+            "message",
+            "content",
+            "text",
+            "artifacts",
+            "generations",
+        ):
+            if key in value:
+                image = walk(value.get(key))
+                if image:
+                    return image
+
+        return ""
+
+    return walk(payload)
 
 
 class BaseProvider(ABC):

--- a/providers/custom_endpoint_impl.py
+++ b/providers/custom_endpoint_impl.py
@@ -1,0 +1,214 @@
+"""Custom full-endpoint image provider."""
+
+import base64
+import json
+import os
+from typing import Any, Dict, List
+from urllib.parse import urlparse
+
+import aiohttp
+from astrbot.api import logger
+
+from .base import (
+    BaseProvider,
+    extract_error_message,
+    extract_image_url_from_response,
+    guess_image_content_type,
+    is_complete_endpoint_url,
+)
+
+
+class CustomEndpointProvider(BaseProvider):
+    """Request exactly the configured URL while adapting payloads by endpoint shape."""
+
+    async def _get_image_bytes(self, image_path_or_url: str) -> bytes:
+        if image_path_or_url.startswith("data:image"):
+            try:
+                return base64.b64decode(image_path_or_url.split(",", 1)[1], validate=False)
+            except Exception as exc:
+                raise RuntimeError(f"Base64 参考图解析失败: {exc}")
+        if image_path_or_url.startswith("http"):
+            logger.info("📥 [自定义通道] 正在下载网络参考图并转码...")
+            headers = {"User-Agent": "Mozilla/5.0"}
+            async with self.session.get(image_path_or_url, headers=headers) as response:
+                if response.status != 200:
+                    raise RuntimeError(f"参考图下载失败，服务器返回状态码: {response.status}")
+                return await response.read()
+        if not os.path.exists(image_path_or_url):
+            raise RuntimeError(f"本地参考图不存在: {image_path_or_url}")
+        with open(image_path_or_url, "rb") as file:
+            return file.read()
+
+    async def _encode_image_to_data_url(self, image_path_or_url: str) -> str:
+        image_bytes = await self._get_image_bytes(image_path_or_url)
+        mime_type = guess_image_content_type(image_path_or_url)
+        return f"data:{mime_type};base64," + base64.b64encode(image_bytes).decode("utf-8")
+
+    async def _encode_reference_images(self, ref_images: List[str]) -> List[str]:
+        encoded_images = []
+        for index, ref_image in enumerate(ref_images, start=1):
+            try:
+                encoded_images.append(await self._encode_image_to_data_url(ref_image))
+            except Exception as exc:
+                raise RuntimeError(f"读取第 {index} 张参考图数据失败: {exc}")
+        return encoded_images
+
+    def _endpoint(self) -> str:
+        endpoint = str(self.config.base_url or "").strip()
+        if not is_complete_endpoint_url(endpoint):
+            raise ValueError(
+                "自定义节点必须填写完整请求路径，例如 "
+                "https://api.example.com/v1/images/generations，不能只填域名或 /v1。"
+            )
+        return endpoint
+
+    def _endpoint_path(self, endpoint: str) -> str:
+        return urlparse(endpoint).path.rstrip("/").lower()
+
+    def _redact_for_log(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        redacted: Dict[str, Any] = {}
+        for key, value in payload.items():
+            if key == "image" or key.startswith("image") or key in {"reference_images"}:
+                if isinstance(value, list):
+                    redacted[key] = [f"<image:{idx + 1}>" for idx, _ in enumerate(value)]
+                elif value:
+                    redacted[key] = "<image>"
+                else:
+                    redacted[key] = value
+            else:
+                redacted[key] = value
+        return redacted
+
+    def _build_chat_payload(self, prompt: str, encoded_images: List[str], api_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        content: List[Dict[str, Any]] = []
+        for image_url in encoded_images:
+            content.append({"type": "image_url", "image_url": {"url": image_url}})
+        content.append(
+            {
+                "type": "text",
+                "text": (
+                    "Generate an image from the following prompt and return only one image URL, "
+                    "data URL, or markdown image link.\n\n"
+                    f"Prompt: {prompt}"
+                ),
+            }
+        )
+        payload = {"model": self.config.model, "messages": [{"role": "user", "content": content}]}
+        payload.update(api_kwargs)
+        return payload
+
+    def _build_responses_payload(
+        self,
+        prompt: str,
+        encoded_images: List[str],
+        api_kwargs: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        content: List[Dict[str, Any]] = [{"type": "input_text", "text": prompt}]
+        for image_url in encoded_images:
+            content.append({"type": "input_image", "image_url": image_url})
+        payload: Dict[str, Any] = {
+            "model": self.config.model,
+            "input": [{"role": "user", "content": content}] if encoded_images else prompt,
+            "tools": [{"type": "image_generation"}],
+        }
+        payload.update(api_kwargs)
+        return payload
+
+    def _build_image_json_payload(
+        self,
+        prompt: str,
+        encoded_images: List[str],
+        api_kwargs: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {"model": self.config.model, "prompt": prompt, "n": 1}
+        for index, image_url in enumerate(encoded_images[:3]):
+            payload["image" if index == 0 else f"image{index + 1}"] = image_url
+        payload.update(api_kwargs)
+        return payload
+
+    async def _post_json(self, endpoint: str, headers: Dict[str, str], payload: Dict[str, Any]) -> str:
+        timeout_obj = aiohttp.ClientTimeout(total=self.config.timeout)
+        logger.info(f"📤 [自定义通道] 请求完整路径: {endpoint}")
+        logger.info(f"📤 [自定义通道] 请求体:\n{json.dumps(self._redact_for_log(payload), ensure_ascii=False)}")
+        async with self.session.post(endpoint, json=payload, headers=headers, timeout=timeout_obj) as response:
+            return await self._parse_response(response, endpoint)
+
+    async def _post_edits_form(
+        self,
+        endpoint: str,
+        headers: Dict[str, str],
+        prompt: str,
+        ref_images: List[str],
+        api_kwargs: Dict[str, Any],
+    ) -> str:
+        data = aiohttp.FormData()
+        for index, ref_image in enumerate(ref_images, start=1):
+            try:
+                image_bytes = await self._get_image_bytes(ref_image)
+            except Exception as exc:
+                raise RuntimeError(f"读取第 {index} 张参考图数据失败: {exc}")
+            data.add_field(
+                "image" if len(ref_images) == 1 else "image[]",
+                image_bytes,
+                filename=f"reference_{index}.png",
+                content_type=guess_image_content_type(ref_image),
+            )
+        data.add_field("prompt", prompt)
+        data.add_field("model", self.config.model)
+        data.add_field("n", "1")
+        for key, value in api_kwargs.items():
+            data.add_field(key, str(value))
+
+        timeout_obj = aiohttp.ClientTimeout(total=self.config.timeout)
+        logger.info(f"📤 [自定义通道] 以 multipart 请求完整路径: {endpoint}")
+        async with self.session.post(endpoint, data=data, headers=headers, timeout=timeout_obj) as response:
+            return await self._parse_response(response, endpoint)
+
+    async def _parse_response(self, response: aiohttp.ClientResponse, endpoint: str) -> str:
+        text = await response.text()
+        if response.status >= 400:
+            logger.error("💥 自定义通道 API 返回错误:\n" + text)
+            raise RuntimeError(f"HTTP {response.status}: {extract_error_message(text)}")
+
+        try:
+            payload = json.loads(text)
+        except Exception:
+            payload = text
+
+        image_url = extract_image_url_from_response(payload, endpoint)
+        if image_url:
+            return image_url
+        raise ValueError("自定义接口返回结构异常，未找到图片数据: " + str(payload))
+
+    async def generate_image(self, prompt: str, **kwargs: Any) -> str:
+        current_key = self.get_current_key()
+        if not current_key:
+            raise ValueError("节点未配置 API Key！")
+        if not self.config.model:
+            raise ValueError("自定义节点未配置模型名！")
+
+        endpoint = self._endpoint()
+        endpoint_path = self._endpoint_path(endpoint)
+        ref_images = self.get_reference_images(**kwargs)
+        internal_keys = {"user_refs", "user_ref", "persona_refs", "persona_ref"}
+        api_kwargs = {key: value for key, value in kwargs.items() if key not in internal_keys}
+        headers = {"Authorization": "Bearer " + current_key}
+
+        logger.info(f"📝 [自定义通道] 最终发送给 API 的核心提示词:\n{prompt}")
+
+        if endpoint_path.endswith("/images/edits") and not ref_images:
+            raise ValueError("自定义 /images/edits 完整路径需要至少一张参考图。")
+        if endpoint_path.endswith("/images/edits"):
+            return await self._post_edits_form(endpoint, headers, prompt, ref_images, api_kwargs)
+
+        encoded_images = await self._encode_reference_images(ref_images)
+        headers["Content-Type"] = "application/json"
+
+        if endpoint_path.endswith("/chat/completions"):
+            payload = self._build_chat_payload(prompt, encoded_images, api_kwargs)
+        elif endpoint_path.endswith("/responses"):
+            payload = self._build_responses_payload(prompt, encoded_images, api_kwargs)
+        else:
+            payload = self._build_image_json_payload(prompt, encoded_images, api_kwargs)
+
+        return await self._post_json(endpoint, headers, payload)

--- a/providers/openai_chat_impl.py
+++ b/providers/openai_chat_impl.py
@@ -3,13 +3,18 @@ AstrBot 万象画卷插件 v3.1 - OpenAI Chat 兼容实现
 功能：支持高阶多模态参数动态透传 (兼容 Midjourney/Gemini 等走 Chat 通道的代理节点)
 """
 import aiohttp
-import re
 import json
 import base64
 from typing import Any
 from astrbot.api import logger
 
-from .base import BaseProvider, build_chat_completions_endpoint, guess_image_content_type
+from .base import (
+    BaseProvider,
+    build_chat_completions_endpoint,
+    extract_error_message,
+    extract_image_url_from_response,
+    guess_image_content_type,
+)
 
 class OpenAIChatProvider(BaseProvider):
 
@@ -111,22 +116,10 @@ class OpenAIChatProvider(BaseProvider):
             status = response.status
             if status != 200:
                 error_text = await response.text()
-                raise RuntimeError("HTTP " + str(status) + ": " + error_text)
+                raise RuntimeError("HTTP " + str(status) + ": " + extract_error_message(error_text))
             
             result = await response.json()
-            if "choices" in result and len(result["choices"]) > 0:
-                content = result["choices"][0].get("message", {}).get("content", "")
-                if isinstance(content, list):
-                    content = "\n".join(str(item.get("text", item)) if isinstance(item, dict) else str(item) for item in content)
-                content = str(content).strip()
-                match = re.search(r'!\[.*?\]\((.*?)\)', content)
-                if match:
-                    return match.group(1)
-                match = re.search(r'(https?://[^\s\]\)"\']+)', content)
-                if match:
-                    return match.group(1)
-                if content.startswith("http") or content.startswith("data:image"):
-                    return content
-                raise ValueError("Chat接口未返回有效图片链接。模型原话: " + content)
-            else:
-                raise ValueError("API返回结构异常: " + str(result))
+            image_url = extract_image_url_from_response(result, self.config.base_url)
+            if image_url:
+                return image_url
+            raise ValueError("Chat接口未返回有效图片链接。API原始返回: " + str(result))

--- a/providers/openai_impl.py
+++ b/providers/openai_impl.py
@@ -2,7 +2,6 @@ import aiohttp
 import base64
 import json
 from typing import Any
-from urllib.parse import urljoin
 
 from astrbot.api import logger
 
@@ -10,8 +9,9 @@ from .base import (
     BaseProvider,
     build_image_edits_endpoint,
     build_image_generations_endpoint,
+    extract_error_message,
+    extract_image_url_from_response,
     guess_image_content_type,
-    strip_known_endpoint_path,
 )
 
 class OpenAIProvider(BaseProvider):
@@ -44,15 +44,6 @@ class OpenAIProvider(BaseProvider):
         image_bytes = await self._get_image_bytes(image_path_or_url)
         mime_type = self._content_type(image_path_or_url)
         return f"data:{mime_type};base64," + base64.b64encode(image_bytes).decode("utf-8")
-
-    def _response_base_url(self, base_url: str) -> str:
-        api_root = strip_known_endpoint_path(base_url)
-        return api_root[:-3] if api_root.endswith("/v1") else api_root
-
-    def _resolve_image_url(self, img_url: str, base_url: str) -> str:
-        if img_url.startswith("http") or img_url.startswith("data:"):
-            return img_url
-        return urljoin(self._response_base_url(base_url).rstrip("/") + "/", img_url.lstrip("/"))
 
     async def generate_image(self, prompt: str, **kwargs: Any) -> str:
         current_key = self.get_current_key()
@@ -145,32 +136,13 @@ class OpenAIProvider(BaseProvider):
         if status != 200:
             error_text = await response.text()
             logger.error("💥 API 返回错误:\n" + error_text)
-            error_msg = error_text
-            try:
-                error_json = json.loads(error_text)
-                if "error" in error_json and "message" in error_json["error"]:
-                    error_msg = error_json["error"]["message"]
-            except Exception:
-                pass
+            error_msg = extract_error_message(error_text)
 
             raise RuntimeError("HTTP " + str(status) + ": " + error_msg)
 
         result = await response.json()
-
-        if "data" in result and len(result["data"]) > 0:
-            data_item = result["data"][0]
-            if "b64_json" in data_item:
-                return "data:image/png;base64," + data_item["b64_json"]
-            if "url" in data_item:
-                return self._resolve_image_url(str(data_item["url"]), base_url)
-
-        if "images" in result and isinstance(result["images"], list) and result["images"]:
-            image_item = result["images"][0]
-            if isinstance(image_item, dict) and "url" in image_item:
-                return self._resolve_image_url(str(image_item["url"]), base_url)
-            if isinstance(image_item, dict) and "b64_json" in image_item:
-                return "data:image/png;base64," + image_item["b64_json"]
-            if isinstance(image_item, str):
-                return self._resolve_image_url(image_item, base_url)
+        image_url = extract_image_url_from_response(result, base_url)
+        if image_url:
+            return image_url
 
         raise ValueError("API 返回结构异常，未找到图片数据: " + str(result))

--- a/tests/test_custom_endpoint.py
+++ b/tests/test_custom_endpoint.py
@@ -1,0 +1,254 @@
+import base64
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+PACKAGE_PARENT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PACKAGE_PARENT))
+
+astrbot_module = types.ModuleType("astrbot")
+astrbot_api_module = types.ModuleType("astrbot.api")
+astrbot_event_module = types.ModuleType("astrbot.api.event")
+
+
+class _Logger:
+    def info(self, *args, **kwargs):
+        pass
+
+    def warning(self, *args, **kwargs):
+        pass
+
+    def error(self, *args, **kwargs):
+        pass
+
+
+astrbot_api_module.logger = _Logger()
+astrbot_event_module.AstrMessageEvent = object
+sys.modules.setdefault("astrbot", astrbot_module)
+sys.modules.setdefault("astrbot.api", astrbot_api_module)
+sys.modules.setdefault("astrbot.api.event", astrbot_event_module)
+
+from astrbot_plugin_omnidraw_ghfast.models import ProviderConfig, _normalize_api_type
+from astrbot_plugin_omnidraw_ghfast.providers.base import (
+    extract_image_url_from_response,
+    is_complete_endpoint_url,
+)
+from astrbot_plugin_omnidraw_ghfast.providers.custom_endpoint_impl import CustomEndpointProvider
+
+
+def _long_b64() -> str:
+    return base64.b64encode(b"image-bytes" * 20).decode("ascii")
+
+
+class FakeResponse:
+    def __init__(self, payload, status=200):
+        self.payload = payload
+        self.status = status
+
+    async def text(self):
+        return json.dumps(self.payload)
+
+
+class FakePost:
+    def __init__(self, response):
+        self.response = response
+
+    async def __aenter__(self):
+        return self.response
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class FakeSession:
+    def __init__(self, response):
+        self.response = response
+        self.posts = []
+        self.gets = []
+
+    def post(self, url, **kwargs):
+        self.posts.append({"url": url, **kwargs})
+        return FakePost(self.response)
+
+    def get(self, url, **kwargs):
+        self.gets.append({"url": url, **kwargs})
+        return FakePost(self.response)
+
+
+class CustomEndpointHelpersTest(unittest.TestCase):
+    def test_custom_api_type_is_preserved(self):
+        self.assertEqual(_normalize_api_type("custom_endpoint", is_video=False), "custom_endpoint")
+        self.assertEqual(_normalize_api_type("自定义", is_video=False), "custom_endpoint")
+
+    def test_complete_endpoint_validation_rejects_roots(self):
+        self.assertTrue(is_complete_endpoint_url("https://api.example.com/v1/images/generations"))
+        self.assertTrue(is_complete_endpoint_url("https://ark.cn-beijing.volces.com/api/v3/images/generations"))
+        self.assertFalse(is_complete_endpoint_url("https://api.example.com"))
+        self.assertFalse(is_complete_endpoint_url("https://api.example.com/v1"))
+        self.assertFalse(is_complete_endpoint_url("https://api.example.com/api"))
+
+    def test_extracts_common_image_shapes(self):
+        endpoint = "https://api.example.com/v1/images/generations"
+        self.assertEqual(
+            extract_image_url_from_response({"data": [{"url": "https://cdn.example.com/a.png"}]}, endpoint),
+            "https://cdn.example.com/a.png",
+        )
+        self.assertTrue(
+            extract_image_url_from_response({"data": [{"b64_json": _long_b64()}]}, endpoint).startswith(
+                "data:image/png;base64,"
+            )
+        )
+        self.assertEqual(
+            extract_image_url_from_response(
+                {"choices": [{"message": {"content": "![image](https://cdn.example.com/chat.png)"}}]},
+                endpoint,
+            ),
+            "https://cdn.example.com/chat.png",
+        )
+        self.assertEqual(
+            extract_image_url_from_response(
+                {"choices": [{"message": {"content": [{"type": "text", "text": "https://cdn.example.com/list.png"}]}}]},
+                endpoint,
+            ),
+            "https://cdn.example.com/list.png",
+        )
+        self.assertTrue(
+            extract_image_url_from_response({"output": [{"type": "image_generation_call", "result": _long_b64()}]}, endpoint).startswith(
+                "data:image/png;base64,"
+            )
+        )
+        self.assertTrue(
+            extract_image_url_from_response({"image": _long_b64()}, endpoint).startswith("data:image/png;base64,")
+        )
+        self.assertEqual(
+            extract_image_url_from_response({"images": [{"url": "/files/out.png"}]}, endpoint),
+            "https://api.example.com/files/out.png",
+        )
+        self.assertEqual(
+            extract_image_url_from_response({"image": "files/from-image-key.webp"}, endpoint),
+            "https://api.example.com/files/from-image-key.webp",
+        )
+
+
+class CustomEndpointProviderTest(unittest.IsolatedAsyncioTestCase):
+    def _provider(self, endpoint, response_payload):
+        config = ProviderConfig(
+            id="custom_node",
+            api_type="custom_endpoint",
+            base_url=endpoint,
+            api_keys=["test-key"],
+            model="image-model",
+            timeout=30.0,
+        )
+        session = FakeSession(FakeResponse(response_payload))
+        return CustomEndpointProvider(config, session), session
+
+    async def test_posts_exact_image_endpoint(self):
+        endpoint = "https://api.example.com/v1/images/generations"
+        provider, session = self._provider(endpoint, {"data": [{"url": "https://cdn.example.com/out.png"}]})
+
+        result = await provider.generate_image("draw a cat", size="1024x1024")
+
+        self.assertEqual(result, "https://cdn.example.com/out.png")
+        self.assertEqual(session.posts[0]["url"], endpoint)
+        self.assertEqual(session.posts[0]["json"]["prompt"], "draw a cat")
+        self.assertEqual(session.posts[0]["json"]["size"], "1024x1024")
+
+    async def test_custom_image_payload_uses_siliconflow_reference_fields(self):
+        endpoint = "https://api.example.com/v1/images/generations"
+        provider, session = self._provider(endpoint, {"images": [{"url": "https://cdn.example.com/out.png"}]})
+        ref = "data:image/png;base64," + _long_b64()
+        ref2 = "data:image/png;base64," + base64.b64encode(b"ref-2" * 30).decode("ascii")
+        ref3 = "data:image/png;base64," + base64.b64encode(b"ref-3" * 30).decode("ascii")
+
+        await provider.generate_image("edit a cat", user_refs=[ref, ref2, ref3])
+
+        self.assertEqual(session.posts[0]["url"], endpoint)
+        self.assertEqual(session.posts[0]["json"]["image"], ref)
+        self.assertEqual(session.posts[0]["json"]["image2"], ref2)
+        self.assertEqual(session.posts[0]["json"]["image3"], ref3)
+        self.assertNotIn("images", session.posts[0]["json"])
+
+    async def test_preserves_exact_custom_endpoint_url(self):
+        endpoint = "https://api.example.com/v1/images/generations/"
+        provider, session = self._provider(endpoint, {"data": [{"url": "https://cdn.example.com/out.png"}]})
+
+        await provider.generate_image("draw a cat")
+
+        self.assertEqual(session.posts[0]["url"], endpoint)
+
+    async def test_rejects_edits_endpoint_without_reference_image(self):
+        endpoint = "https://api.example.com/v1/images/edits"
+        provider, session = self._provider(endpoint, {"data": [{"url": "unused"}]})
+
+        with self.assertRaisesRegex(ValueError, "至少一张参考图"):
+            await provider.generate_image("edit a cat")
+
+        self.assertEqual(session.posts, [])
+
+    async def test_edits_endpoint_uses_multipart_image_array_for_multiple_references(self):
+        endpoint = "https://api.example.com/v1/images/edits"
+        provider, session = self._provider(endpoint, {"data": [{"url": "https://cdn.example.com/out.png"}]})
+        ref = "data:image/png;base64," + _long_b64()
+        ref2 = "data:image/png;base64," + base64.b64encode(b"ref-2" * 30).decode("ascii")
+
+        await provider.generate_image("edit a cat", user_refs=[ref, ref2])
+
+        self.assertEqual(session.posts[0]["url"], endpoint)
+        form = session.posts[0]["data"]
+        image_field_names = [
+            field[0]["name"]
+            for field in getattr(form, "_fields", [])
+            if field and field[0].get("name", "").startswith("image")
+        ]
+        self.assertEqual(image_field_names, ["image[]", "image[]"])
+
+    async def test_posts_exact_chat_endpoint(self):
+        endpoint = "https://api.example.com/v1/chat/completions"
+        provider, session = self._provider(
+            endpoint,
+            {"choices": [{"message": {"content": "https://cdn.example.com/chat-out.png"}}]},
+        )
+
+        result = await provider.generate_image("draw a cat")
+
+        self.assertEqual(result, "https://cdn.example.com/chat-out.png")
+        self.assertEqual(session.posts[0]["url"], endpoint)
+        self.assertIn("messages", session.posts[0]["json"])
+
+    async def test_posts_exact_responses_endpoint(self):
+        endpoint = "https://api.example.com/v1/responses"
+        provider, session = self._provider(
+            endpoint,
+            {"output": [{"type": "image_generation_call", "result": _long_b64()}]},
+        )
+
+        result = await provider.generate_image("draw a cat")
+
+        self.assertTrue(result.startswith("data:image/png;base64,"))
+        self.assertEqual(session.posts[0]["url"], endpoint)
+        self.assertIn("tools", session.posts[0]["json"])
+
+    async def test_rejects_incomplete_custom_endpoint(self):
+        provider, session = self._provider("https://api.example.com/v1", {"data": [{"url": "unused"}]})
+
+        with self.assertRaisesRegex(ValueError, "完整请求路径"):
+            await provider.generate_image("draw a cat")
+
+        self.assertEqual(session.posts, [])
+
+    async def test_local_reference_missing_does_not_post(self):
+        endpoint = "https://api.example.com/v1/images/generations"
+        provider, session = self._provider(endpoint, {"data": [{"url": "unused"}]})
+
+        with self.assertRaisesRegex(RuntimeError, "本地参考图不存在"):
+            await provider.generate_image("edit a cat", user_refs=["C:/definitely/missing.png"])
+
+        self.assertEqual(session.posts, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a custom_endpoint image provider mode that only requests the exact configured full URL
- expose the new mode in AstrBot native config and Pages UI with full-path validation
- centralize image/error response parsing across OpenAI Images, Responses API, Chat-style relays, and common relay formats
- support SiliconFlow-style image/image2/image3 reference fields, OpenAI edits multipart image[] fields, and local validation for edits endpoints without references
- document the new mode, add astrbot_version metadata, and bump plugin version to 3.3.12

## Tests
- python -m unittest discover -s tests -v (12 tests)
- python -m compileall -q .
- Python JSON parse smoke test for _conf_schema.json
- node --check pages/插件配置/app.js
- git diff --check origin/main..HEAD

## AstrBot review follow-up
- Addressed the forced AstrBot-skill subagent review findings: exact URL preservation, SiliconFlow multi-reference payloads, /images/edits guardrails, multipart field names, Chat relay wording, and metadata compatibility.