### PR TITLE
fix: restore full provider prompt logs

### DIFF
--- a/providers/base.py
+++ b/providers/base.py
@@ -259,11 +259,11 @@ def summarize_text_for_log(value: str, max_string_length: int = 160, key_hint: s
     key_lowered = key_hint.lower()
     if lowered.startswith("data:image"):
         return _image_data_url_summary(stripped)
-    if any(marker in key_lowered for marker in IMAGE_LOG_KEY_MARKERS) and _looks_like_base64_blob(stripped):
-        return f"<image_base64 chars={len(stripped)}>"
     if _is_prompt_log_key(key_lowered):
         label = "prompt" if "prompt" in key_lowered else key_lowered or "text"
         return f"<{label} chars={len(text)}>"
+    if _looks_like_base64_blob(stripped):
+        return f"<image_base64 chars={len(stripped)}>"
     redacted_text = _redact_text_fragments_for_log(text)
     if len(redacted_text) <= max_string_length:
         return redacted_text

--- a/providers/custom_endpoint_impl.py
+++ b/providers/custom_endpoint_impl.py
@@ -188,7 +188,7 @@ class CustomEndpointProvider(BaseProvider):
         api_kwargs = {key: value for key, value in kwargs.items() if key not in internal_keys}
         headers = {"Authorization": "Bearer " + current_key}
 
-        logger.info(f"📝 [自定义通道] 最终提示词摘要: {summarize_text_for_log(prompt, key_hint='prompt')}")
+        logger.info(f"📝 [自定义通道] 最终发送给 API 的核心提示词:\n{prompt}")
 
         if endpoint_path.endswith("/images/edits") and not ref_images:
             raise ValueError("自定义 /images/edits 完整路径需要至少一张参考图。")

--- a/providers/openai_chat_impl.py
+++ b/providers/openai_chat_impl.py
@@ -15,7 +15,6 @@ from .base import (
     guess_image_content_type,
     summarize_payload_json_for_log,
     summarize_response_text_for_log,
-    summarize_text_for_log,
 )
 
 class OpenAIChatProvider(BaseProvider):
@@ -86,7 +85,7 @@ class OpenAIChatProvider(BaseProvider):
             "text": full_prompt
         })
         
-        logger.info(f"📝 [Chat/Vision通道] 最终提示词摘要: {summarize_text_for_log(prompt, key_hint='prompt')}")
+        logger.info(f"📝 [Chat/Vision通道] 最终发送给 API 的核心提示词:\n{prompt}")
 
         payload = {
             "model": self.config.model,

--- a/providers/openai_chat_impl.py
+++ b/providers/openai_chat_impl.py
@@ -85,7 +85,7 @@ class OpenAIChatProvider(BaseProvider):
             "text": full_prompt
         })
         
-        logger.info(f"📝 [Chat/Vision通道] 最终发送给 API 的核心提示词:\n{prompt}")
+        logger.info(f"📝 [Chat/Vision通道] 最终发送给 API 的核心提示词:\n{full_prompt}")
 
         payload = {
             "model": self.config.model,

--- a/providers/openai_impl.py
+++ b/providers/openai_impl.py
@@ -13,7 +13,6 @@ from .base import (
     guess_image_content_type,
     summarize_payload_json_for_log,
     summarize_response_text_for_log,
-    summarize_text_for_log,
 )
 
 class OpenAIProvider(BaseProvider):
@@ -55,7 +54,7 @@ class OpenAIProvider(BaseProvider):
         base_url = self.config.base_url
         ref_images = self.get_reference_images(**kwargs)
 
-        logger.info(f"📝 [标准通道] 最终提示词摘要: {summarize_text_for_log(prompt, key_hint='prompt')}")
+        logger.info(f"📝 [标准通道] 最终发送给 API 的核心提示词:\n{prompt}")
 
         # 🚀 剥离内置参数，剩下的全是用户或 LLM 透传的高级参数
         internal_keys = {"user_refs", "user_ref", "persona_refs", "persona_ref"}

--- a/tests/test_custom_endpoint.py
+++ b/tests/test_custom_endpoint.py
@@ -210,6 +210,27 @@ class CustomEndpointHelpersTest(unittest.TestCase):
         self.assertIn("<redacted>", message)
         self.assertIn("<image_base64", message)
 
+    def test_error_message_sanitizes_base64_in_result_fields(self):
+        raw_image = base64.b64encode(b"result-image" * 40).decode("ascii")
+        payload = {
+            "error": {
+                "message": {
+                    "output": [
+                        {"type": "image_generation_call", "result": raw_image},
+                    ],
+                    "data": raw_image,
+                }
+            }
+        }
+
+        summary = summarize_payload_for_log(payload)
+        message = extract_error_message(json.dumps(payload))
+
+        self.assertNotIn(raw_image[:40], str(summary))
+        self.assertNotIn(raw_image[:40], message)
+        self.assertIn("<image_base64", str(summary))
+        self.assertIn("<image_base64", message)
+
     def test_plain_text_log_summary_redacts_embedded_secrets_and_data_urls(self):
         image_data_url = "data:image/png;base64," + _long_b64()
         text = "API key: AIzaSyExampleSecret123456789 failed for image " + image_data_url + ". prompt: draw a cat"

--- a/tests/test_custom_endpoint.py
+++ b/tests/test_custom_endpoint.py
@@ -265,6 +265,19 @@ class CustomEndpointProviderTest(unittest.IsolatedAsyncioTestCase):
     def _log_text(self):
         return "\n".join(message for _, message in fake_logger.messages)
 
+    def _prompt_log_text(self):
+        return "\n".join(message for _, message in fake_logger.messages if "核心提示词" in message)
+
+    def _request_summary_log_text(self):
+        return "\n".join(
+            message
+            for _, message in fake_logger.messages
+            if "请求体摘要" in message or "高级参数" in message or "透传摘要" in message
+        )
+
+    def _non_prompt_log_text(self):
+        return "\n".join(message for _, message in fake_logger.messages if "核心提示词" not in message)
+
     async def test_posts_exact_image_endpoint(self):
         endpoint = "https://api.example.com/v1/images/generations"
         provider, session = self._provider(endpoint, {"data": [{"url": "https://cdn.example.com/out.png"}]})
@@ -417,11 +430,15 @@ class CustomEndpointProviderTest(unittest.IsolatedAsyncioTestCase):
                 logs = self._log_text()
                 self.assertNotIn(secret, logs)
                 self.assertNotIn(raw_b64[:40], logs)
-                self.assertNotIn(long_prompt, logs)
-                self.assertNotIn("PROMPT_TAIL_SHOULD_NOT_LOG", logs)
+                self.assertIn(long_prompt, self._prompt_log_text())
+                self.assertIn("PROMPT_TAIL_SHOULD_NOT_LOG", self._prompt_log_text())
                 self.assertIn("<redacted>", logs)
                 self.assertIn("<image_base64", logs)
-                self.assertIn("<prompt chars=", logs)
+                summary_logs = self._request_summary_log_text()
+                self.assertNotIn(long_prompt, summary_logs)
+                self.assertNotIn("PROMPT_TAIL_SHOULD_NOT_LOG", summary_logs)
+                if provider_cls is not OpenAIChatProvider:
+                    self.assertIn("<prompt chars=", summary_logs)
 
     async def test_short_prompts_and_custom_endpoint_queries_do_not_leak_to_logs(self):
         short_prompt = "draw a cat"
@@ -470,10 +487,17 @@ class CustomEndpointProviderTest(unittest.IsolatedAsyncioTestCase):
                 if provider_cls is CustomEndpointProvider:
                     self.assertEqual(session.posts[0]["url"], endpoint)
                 logs = self._log_text()
-                self.assertNotIn(short_prompt, logs)
+                self.assertIn(short_prompt, self._prompt_log_text())
+                self.assertNotIn(short_prompt, self._request_summary_log_text())
                 self.assertNotIn(query_secret, logs)
                 self.assertNotIn("1024x1024", logs)
-                self.assertIn("<prompt chars=", logs)
+                if provider_cls is not OpenAIChatProvider:
+                    summary_logs = self._request_summary_log_text()
+                    self.assertTrue(
+                        "<prompt chars=" in summary_logs
+                        or "<text chars=" in summary_logs
+                        or "<input chars=" in summary_logs
+                    )
                 if query_secret in endpoint:
                     self.assertIn("api_key=<redacted>", logs)
 
@@ -529,11 +553,12 @@ class CustomEndpointProviderTest(unittest.IsolatedAsyncioTestCase):
                 with self.assertRaises(RuntimeError) as raised:
                     await provider.generate_image("draw a cat")
 
-                combined = str(raised.exception) + "\n" + self._log_text()
+                combined = str(raised.exception) + "\n" + self._non_prompt_log_text()
                 self.assertNotIn(query_secret, combined)
                 self.assertNotIn("draw a cat", combined)
                 self.assertIn("API key=<redacted>", combined)
                 self.assertIn("prompt=<redacted>", combined)
+                self.assertIn("draw a cat", self._prompt_log_text())
 
     async def test_unexpected_success_response_exception_is_summarized(self):
         raw_b64 = base64.b64encode(b"unexpected-success-image" * 35).decode("ascii")


### PR DESCRIPTION
## Summary
- restore standalone provider prompt logs to full prompt output for standard, Chat/Vision, and custom full-endpoint channels
- keep request-body logs compact, so payload summaries still redact/summarize prompt fields, image/base64 content, secrets, and custom endpoint query values
- keep error response logs and exceptions sanitized, including base64 returned under generic `result`/`data` fields
- log the actual Chat/Vision `full_prompt` that is sent in the message payload
- do not bump the plugin version in this follow-up change

## AstrBot review follow-up
- Final Subagent review was run with `skill-astrbot-dev` as the required AstrBot reference.
- Addressed its P1 finding by adding value-level base64 summary handling for provider error/response shapes such as `output[].result`.
- Also aligned Chat/Vision full prompt logging with the actual payload text sent to the provider.

## Tests
- `python -m unittest discover -s tests -v` (22 tests)
- `python -m pytest -q` (22 passed, 14 subtests passed)
- `python -m compileall -q .`
- Python JSON parse smoke test for `_conf_schema.json`
- `node --check pages/插件配置/app.js`
- `git diff --check FETCH_HEAD...HEAD`