### PR TITLE
[codex] Add official Gemini image provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 __pycache__/
 *.py[cod]
 .pytest_cache/
-tests/

--- a/README.md
+++ b/README.md
@@ -64,11 +64,13 @@ https://github.com/diaomin66/astrbot_plugin_omnidraw/
 | 字段 | 怎么填 |
 | :--- | :--- |
 | 节点 ID | 自己取一个好记的名字，比如 `image_node_1` |
-| API 类型 | 按你的接口选择：`openai_image` 标准生图、`openai_chat` 对话透传中转站、`custom_endpoint` 自定义完整路径 |
-| Base URL | 标准/对话模式填中转站或官方接口地址，例如 `https://example.com/v1`；自定义模式必须填完整请求 URL |
+| API 类型 | 按你的接口选择：`openai_image` 标准生图、`openai_chat` 对话透传中转站、`gemini_official` Gemini 官方、`custom_endpoint` 自定义完整路径 |
+| Base URL | 标准/对话模式填中转站或官方接口地址，例如 `https://example.com/v1`；Gemini 官方可留空或填 `https://generativelanguage.googleapis.com/v1beta`；自定义模式必须填完整请求 URL |
 | API Keys | 填你的 key，多个 key 可按页面提示添加 |
-| 模型 | 填模型名，例如 `gpt-image-1`、`gemini-xxx-image` 等 |
+| 模型 | 填模型名，例如 `gpt-image-1`、`gemini-3.1-flash-image-preview` 等 |
 | Timeout | 建议画图 120-300，视频 300 或更高 |
+
+`gemini_official` 使用 Google Gemini 原生 `generateContent` 接口，请求会发送到 `/models/{model}:generateContent`，认证使用 `x-goog-api-key`，返回图片会从 `candidates[].content.parts[].inlineData` 解析成 `data:image/...;base64,...`。
 
 `custom_endpoint` 只请求你填写的完整路径，不会自动追加 `/v1`、`/images/generations`、`/images/edits` 或 `/chat/completions`。例如要请求硅基流动、豆包或海外中转站的某个固定接口时，应直接填写 `https://api.example.com/v1/images/generations`、`https://api.example.com/v1/chat/completions` 或服务商文档给出的完整 endpoint。Chat Completions 仅适合会返回图片链接的中转站；官方 OpenAI 生图建议使用 Images 或 Responses 路径。
 

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -174,15 +174,16 @@
             "options": [
               "openai_image",
               "openai_chat",
+              "gemini_official",
               "custom_endpoint"
             ],
-            "hint": "openai_image 适合标准图片接口；openai_chat 适合会返回图片链接的 chat/completions 中转站；custom_endpoint 为自定义完整路径，只请求你填写的完整 URL，不会追加 /v1、/images/generations 或 /chat/completions。",
+            "hint": "openai_image 适合标准图片接口；openai_chat 适合会返回图片链接的 chat/completions 中转站；gemini_official 使用 Google Gemini 官方 generateContent；custom_endpoint 为自定义完整路径，只请求你填写的完整 URL，不会追加 /v1、/images/generations 或 /chat/completions。",
             "default": "openai_image"
           },
           "base_url": {
             "description": "接口地址",
             "type": "string",
-            "hint": "标准/对话模式通常填写 https://api.example.com/v1；自定义模式必须填写完整请求路径，例如 https://api.example.com/v1/images/generations。",
+            "hint": "标准/对话模式通常填写 https://api.example.com/v1；Gemini 官方模式可留空或填写 https://generativelanguage.googleapis.com/v1beta；自定义模式必须填写完整请求路径，例如 https://api.example.com/v1/images/generations。",
             "default": ""
           },
           "api_keys": {
@@ -194,7 +195,7 @@
           "model": {
             "description": "当前模型",
             "type": "string",
-            "hint": "当前默认使用的模型名，应同时存在于下方模型池中。",
+            "hint": "当前默认使用的模型名，应同时存在于下方模型池中。Gemini 官方模式可填 gemini-3.1-flash-image-preview。",
             "default": ""
           },
           "available_models": {

--- a/constants.py
+++ b/constants.py
@@ -9,11 +9,14 @@ DEFAULT_DRAW_PENDING_MESSAGE = "🎨 收到灵感，正在绘制..."
 DEFAULT_SELFIE_PENDING_MESSAGE = "ℹ️ 正在为「{persona_name}」生成自拍，请稍候..."
 DEFAULT_DRAW_ERROR_MESSAGE = "💥 绘制失败: {error}"
 DEFAULT_SELFIE_ERROR_MESSAGE = "💥 自拍生成失败: {error}"
+DEFAULT_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
+DEFAULT_GEMINI_MODEL = "gemini-3.1-flash-image-preview"
 
 class APIType:
     """接口类型枚举"""
     OPENAI_IMAGE = "openai_image"
     OPENAI_CHAT = "openai_chat"  # 新增 Chat 解析出图类型
+    GEMINI_OFFICIAL = "gemini_official"
     CUSTOM_ENDPOINT = "custom_endpoint"
 
 class MessageEmoji:

--- a/core/chain_manager.py
+++ b/core/chain_manager.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import aiohttp
 from astrbot.api import logger
+from ..constants import APIType
 from ..models import PluginConfig
 from ..providers import create_provider
 
@@ -53,7 +54,10 @@ class ChainManager:
                 skipped_errors.append(f"{provider_id}: 节点不存在")
                 logger.warning(f"⚠️ 链路 [{chain_name}] 中的节点 [{provider_id}] 不存在。")
                 continue
-            if not provider_config.base_url or not provider_config.model:
+            if (
+                (not provider_config.base_url or not provider_config.model)
+                and provider_config.api_type != APIType.GEMINI_OFFICIAL
+            ):
                 skipped_errors.append(f"{provider_id}: 缺少接口地址或模型")
                 logger.warning(f"⚠️ 链路 [{chain_name}] 中的节点 [{provider_id}] 缺少接口地址或模型。")
                 continue

--- a/models.py
+++ b/models.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from .constants import (
+    APIType,
+    DEFAULT_GEMINI_MODEL,
     DEFAULT_DRAW_ERROR_MESSAGE,
     DEFAULT_DRAW_PENDING_MESSAGE,
     DEFAULT_SELFIE_ERROR_MESSAGE,
@@ -339,11 +341,13 @@ def _normalize_api_type(value: Any, is_video: bool) -> str:
         if "sync" in lowered or "同步" in raw:
             return "openai_sync"
         return "async_task"
+    if lowered in {"gemini", "gemini_official", "google_gemini"} or "gemini" in lowered or "gemini" in raw.lower():
+        return APIType.GEMINI_OFFICIAL
     if lowered in {"custom_endpoint", "custom"} or "自定义" in raw:
-        return "custom_endpoint"
+        return APIType.CUSTOM_ENDPOINT
     if "chat" in lowered or "对话" in raw:
-        return "openai_chat"
-    return "openai_image"
+        return APIType.OPENAI_CHAT
+    return APIType.OPENAI_IMAGE
 
 
 def _build_provider_config(raw_provider: Any, is_video: bool) -> ProviderConfig:
@@ -360,13 +364,16 @@ def _build_provider_config(raw_provider: Any, is_video: bool) -> ProviderConfig:
         model = model.split(",", 1)[0].strip()
     if not model and available_models:
         model = available_models[0]
+    api_type = _normalize_api_type(raw_provider.get("api_type", raw_provider.get("接口模式", "")), is_video)
+    if api_type == APIType.GEMINI_OFFICIAL and not model:
+        model = DEFAULT_GEMINI_MODEL
     if model and model not in available_models:
         available_models.insert(0, model)
 
     default_timeout = 300.0 if is_video else 60.0
     return ProviderConfig(
         id=str(raw_provider.get("id", raw_provider.get("节点ID", ""))).strip(),
-        api_type=_normalize_api_type(raw_provider.get("api_type", raw_provider.get("接口模式", "")), is_video),
+        api_type=api_type,
         base_url=str(
             raw_provider.get(
                 "base_url",

--- a/pages/插件配置/app.js
+++ b/pages/插件配置/app.js
@@ -12,6 +12,10 @@ const defaultCacheConfig = {
     max_cache_size_mb: 512
 };
 
+const GEMINI_OFFICIAL_BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
+const GEMINI_DEFAULT_MODEL = "gemini-3.1-flash-image-preview";
+const GEMINI_DEFAULT_MODELS = [GEMINI_DEFAULT_MODEL, "gemini-3-pro-image-preview"];
+
 const mockConfig = {
     permission_config: { usable_users: "", allowed_users: "", blocked_users: "", unlimited_groups: "" },
     usage_config: {
@@ -154,6 +158,24 @@ function normalizeModelList(value) {
 
 function normalizeTextAreaKeys(value) {
     return Array.isArray(value) ? value.join("\n") : String(value || "");
+}
+
+function mergeUniqueModels(...groups) {
+    return [...new Set(groups.flat().map((item) => String(item || "").trim()).filter(Boolean))];
+}
+
+function applyImageProviderDefaults(provider) {
+    if (!provider || provider.api_type !== "gemini_official") return provider;
+    if (!String(provider.base_url || "").trim() || provider.base_url === "https://api.example.com/v1") {
+        provider.base_url = GEMINI_OFFICIAL_BASE_URL;
+    }
+    provider.available_models = mergeUniqueModels(provider.available_models || [], GEMINI_DEFAULT_MODELS);
+    if (!String(provider.model || "").trim()) {
+        provider.model = provider.available_models[0] || GEMINI_DEFAULT_MODEL;
+    }
+    const timeout = parseFloat(provider.timeout);
+    provider.timeout = Number.isFinite(timeout) && timeout >= 120 ? timeout : 120;
+    return provider;
 }
 
 function readNonnegativeIntInput(id, fallback = 0) {
@@ -838,6 +860,7 @@ function renderProviderCard(p, i, isVideo) {
         : [
             ["openai_image", "标准生图"],
             ["openai_chat", "对话透传"],
+            ["gemini_official", "Gemini"],
             ["custom_endpoint", "自定义"]
         ];
 
@@ -1187,7 +1210,10 @@ function setupEventDelegation() {
             const sync = apiChip.getAttribute("data-sync");
             const idx = parseInt(apiChip.getAttribute("data-index"), 10);
             const val = apiChip.getAttribute("data-val");
-            if (sync === "prov-api") state.providers[idx].api_type = val;
+            if (sync === "prov-api") {
+                state.providers[idx].api_type = val;
+                applyImageProviderDefaults(state.providers[idx]);
+            }
             if (sync === "vid-api") state.video_providers[idx].api_type = val;
             if (sync === "prov-model-select") state.providers[idx].model = val;
             if (sync === "vid-model-select") state.video_providers[idx].model = val;
@@ -1420,7 +1446,7 @@ async function init() {
     state.providers = (rawConfig.providers || []).map((p) => {
         const availableModels = normalizeModelList(p.available_models?.length ? p.available_models : (p.model || p["模型名称"] || ""));
         const model = p.model && !String(p.model).includes(",") ? p.model : (availableModels[0] || "");
-        return {
+        return applyImageProviderDefaults({
             id: p.id || p["节点ID"] || "",
             api_type: p.api_type || p["接口模式"] || "openai_image",
             base_url: p.base_url || p["接口地址 (需含/v1)"] || "",
@@ -1428,7 +1454,7 @@ async function init() {
             available_models: availableModels,
             timeout: p.timeout || p["超时时间(秒)"] || 60,
             api_keys: normalizeTextAreaKeys(p.api_keys || p["API密钥"] || "")
-        };
+        });
     });
 
     state.video_providers = (rawConfig.video_providers || []).map((p) => {

--- a/pages/插件配置/app.js
+++ b/pages/插件配置/app.js
@@ -1446,7 +1446,7 @@ async function init() {
     state.providers = (rawConfig.providers || []).map((p) => {
         const availableModels = normalizeModelList(p.available_models?.length ? p.available_models : (p.model || p["模型名称"] || ""));
         const model = p.model && !String(p.model).includes(",") ? p.model : (availableModels[0] || "");
-        return applyImageProviderDefaults({
+        return {
             id: p.id || p["节点ID"] || "",
             api_type: p.api_type || p["接口模式"] || "openai_image",
             base_url: p.base_url || p["接口地址 (需含/v1)"] || "",
@@ -1454,7 +1454,7 @@ async function init() {
             available_models: availableModels,
             timeout: p.timeout || p["超时时间(秒)"] || 60,
             api_keys: normalizeTextAreaKeys(p.api_keys || p["API密钥"] || "")
-        });
+        };
     });
 
     state.video_providers = (rawConfig.video_providers || []).map((p) => {

--- a/pages/插件配置/index.html
+++ b/pages/插件配置/index.html
@@ -449,7 +449,7 @@
                     <div class="card-header space-between">
                         <div>
                             <h3>图像算力节点</h3>
-                            <p>OpenAI Images 或 Chat 兼容接口。</p>
+                            <p>OpenAI Images、Chat 兼容接口、Gemini 官方或自定义完整路径。</p>
                         </div>
                         <button data-action="add-provider" class="btn-secondary" type="button">添加生图节点</button>
                     </div>

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -5,6 +5,7 @@ from ..models import ProviderConfig
 from ..constants import APIType
 from .base import BaseProvider
 from .custom_endpoint_impl import CustomEndpointProvider
+from .gemini_official_impl import GeminiOfficialProvider
 from .openai_impl import OpenAIProvider
 from .openai_chat_impl import OpenAIChatProvider
 
@@ -15,6 +16,8 @@ def create_provider(config: ProviderConfig, session: aiohttp.ClientSession) -> B
     # ===== 加入了 openai_chat 的识别分支 =====
     elif config.api_type == APIType.OPENAI_CHAT:
         return OpenAIChatProvider(config, session)
+    elif config.api_type == APIType.GEMINI_OFFICIAL:
+        return GeminiOfficialProvider(config, session)
     elif config.api_type == APIType.CUSTOM_ENDPOINT:
         return CustomEndpointProvider(config, session)
     else:

--- a/providers/base.py
+++ b/providers/base.py
@@ -354,6 +354,45 @@ def extract_image_url_from_response(payload: Any, base_url: str) -> str:
             return ""
         return walk(value)
 
+    def from_inline_data(value: Any) -> str:
+        if not isinstance(value, dict):
+            return ""
+        if "mimeType" not in value and "mime_type" not in value:
+            return ""
+        data_value = value.get("data")
+        if not isinstance(data_value, str):
+            return ""
+        data = data_value.strip()
+        if not data:
+            return ""
+        mime_type = str(value.get("mimeType") or value.get("mime_type") or "image/png").strip() or "image/png"
+        return f"data:{mime_type};base64," + re.sub(r"\s+", "", data)
+
+    def from_gemini_candidates(value: Any) -> str:
+        if not isinstance(value, dict):
+            return ""
+        candidates = value.get("candidates")
+        if not isinstance(candidates, list):
+            return ""
+        for candidate in candidates:
+            if not isinstance(candidate, dict):
+                continue
+            content = candidate.get("content") or {}
+            parts = content.get("parts") if isinstance(content, dict) else None
+            if not isinstance(parts, list):
+                continue
+            last_inline_image = ""
+            for part in parts:
+                if not isinstance(part, dict):
+                    continue
+                for key in ("inlineData", "inline_data"):
+                    image = from_inline_data(part.get(key))
+                    if image:
+                        last_inline_image = image
+            if last_inline_image:
+                return last_inline_image
+        return ""
+
     def walk(value: Any) -> str:
         if isinstance(value, str):
             return from_text(value)
@@ -365,6 +404,15 @@ def extract_image_url_from_response(payload: Any, base_url: str) -> str:
             return ""
         if not isinstance(value, dict):
             return ""
+
+        gemini_image = from_gemini_candidates(value)
+        if gemini_image:
+            return gemini_image
+
+        for key in ("inlineData", "inline_data"):
+            image = from_inline_data(value.get(key))
+            if image:
+                return image
 
         if value.get("type") == "image_generation_call" and value.get("result"):
             image = coerce_image_value(value.get("result"), assume_base64=True)
@@ -411,6 +459,10 @@ def extract_image_url_from_response(payload: Any, base_url: str) -> str:
             "message",
             "content",
             "text",
+            "candidates",
+            "parts",
+            "inlineData",
+            "inline_data",
             "artifacts",
             "generations",
         ):

--- a/providers/base.py
+++ b/providers/base.py
@@ -366,7 +366,14 @@ def extract_image_url_from_response(payload: Any, base_url: str) -> str:
         if not data:
             return ""
         mime_type = str(value.get("mimeType") or value.get("mime_type") or "image/png").strip() or "image/png"
-        return f"data:{mime_type};base64," + re.sub(r"\s+", "", data)
+        if not mime_type.split(";", 1)[0].lower().startswith("image/"):
+            return ""
+        compact_data = re.sub(r"\s+", "", data)
+        try:
+            base64.b64decode(compact_data, validate=True)
+        except Exception:
+            return ""
+        return f"data:{mime_type};base64,{compact_data}"
 
     def from_gemini_candidates(value: Any) -> str:
         if not isinstance(value, dict):

--- a/providers/gemini_official_impl.py
+++ b/providers/gemini_official_impl.py
@@ -1,0 +1,229 @@
+"""Google Gemini native image provider."""
+
+import base64
+import json
+import math
+import os
+import re
+from typing import Any, Dict, List
+from urllib.parse import quote
+
+import aiohttp
+from astrbot.api import logger
+
+from ..constants import DEFAULT_GEMINI_BASE_URL, DEFAULT_GEMINI_MODEL
+from .base import (
+    BaseProvider,
+    extract_error_message,
+    extract_image_url_from_response,
+    guess_image_content_type,
+    normalize_base_url,
+    summarize_payload_json_for_log,
+    summarize_response_text_for_log,
+    summarize_url_for_log,
+)
+
+
+MAX_REFERENCE_IMAGES = 14
+ALLOWED_ASPECT_RATIOS = ("1:1", "3:4", "4:3", "9:16", "16:9")
+
+
+class GeminiOfficialProvider(BaseProvider):
+    """Call Google's native Gemini generateContent endpoint."""
+
+    async def _get_image_bytes(self, image_path_or_url: str) -> bytes:
+        if image_path_or_url.startswith("data:image"):
+            try:
+                return base64.b64decode(image_path_or_url.split(",", 1)[1], validate=False)
+            except Exception as exc:
+                raise RuntimeError(f"Base64 参考图解析失败: {exc}")
+        if image_path_or_url.startswith("http"):
+            logger.info("📥 [Gemini官方通道] 正在下载网络参考图并转码...")
+            headers = {"User-Agent": "Mozilla/5.0"}
+            async with self.session.get(image_path_or_url, headers=headers) as response:
+                if response.status != 200:
+                    raise RuntimeError(f"参考图下载失败，服务器返回状态码: {response.status}")
+                return await response.read()
+        if not os.path.exists(image_path_or_url):
+            raise RuntimeError(f"本地参考图不存在: {image_path_or_url}")
+        with open(image_path_or_url, "rb") as file:
+            return file.read()
+
+    async def _inline_image_part(self, image_path_or_url: str) -> Dict[str, Any]:
+        image_bytes = await self._get_image_bytes(image_path_or_url)
+        return {
+            "inline_data": {
+                "mime_type": guess_image_content_type(image_path_or_url),
+                "data": base64.b64encode(image_bytes).decode("ascii"),
+            }
+        }
+
+    def _request_model(self, api_kwargs: Dict[str, Any]) -> str:
+        model = str(api_kwargs.pop("model", "") or self.config.model or DEFAULT_GEMINI_MODEL).strip()
+        if model.startswith("models/"):
+            return model.split("/", 1)[1]
+        return model
+
+    def _endpoint(self, model: str) -> str:
+        base_url = normalize_base_url(self.config.base_url) or DEFAULT_GEMINI_BASE_URL
+        if ":generateContent" in base_url:
+            return base_url
+        if "/models/" in base_url:
+            return f"{base_url}:generateContent"
+        if base_url.endswith("/models"):
+            base_url = base_url[: -len("/models")]
+        return f"{base_url}/models/{quote(model, safe='-._~')}:generateContent"
+
+    def _pop_any(self, params: Dict[str, Any], *names: str) -> Any:
+        for name in names:
+            if name in params:
+                return params.pop(name)
+        return None
+
+    def _normalize_modalities(self, value: Any) -> List[str]:
+        if isinstance(value, (list, tuple)):
+            raw_items = value
+        else:
+            raw_items = re.split(r"[\s,]+", str(value or ""))
+        items = []
+        for item in raw_items:
+            text = str(item or "").strip().upper()
+            if text:
+                items.append("IMAGE" if text == "IMG" else text)
+        return items or ["TEXT", "IMAGE"]
+
+    def _aspect_ratio_from_size(self, value: Any) -> str:
+        match = re.fullmatch(r"\s*(\d+)\s*[xX×]\s*(\d+)\s*", str(value or ""))
+        if not match:
+            return ""
+        width, height = int(match.group(1)), int(match.group(2))
+        if width <= 0 or height <= 0:
+            return ""
+        ratio = width / height
+        best = min(
+            ALLOWED_ASPECT_RATIOS,
+            key=lambda item: abs(math.log(ratio / (int(item.split(":")[0]) / int(item.split(":")[1])))),
+        )
+        return best
+
+    def _build_generation_config(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        modalities = self._pop_any(params, "responseModalities", "response_modalities")
+        generation_config: Dict[str, Any] = {
+            "responseModalities": self._normalize_modalities(modalities or ["TEXT", "IMAGE"])
+        }
+
+        key_map = {
+            "temperature": "temperature",
+            "topP": "topP",
+            "top_p": "topP",
+            "topK": "topK",
+            "top_k": "topK",
+            "candidateCount": "candidateCount",
+            "candidate_count": "candidateCount",
+            "maxOutputTokens": "maxOutputTokens",
+            "max_output_tokens": "maxOutputTokens",
+            "seed": "seed",
+        }
+        for source_key, target_key in key_map.items():
+            if source_key in params:
+                generation_config[target_key] = params.pop(source_key)
+
+        aspect_ratio = self._pop_any(params, "aspectRatio", "aspect_ratio")
+        if not aspect_ratio:
+            aspect_ratio = self._aspect_ratio_from_size(self._pop_any(params, "size"))
+        image_size = self._pop_any(params, "imageSize", "image_size")
+        image_options = {}
+        if aspect_ratio:
+            image_options["aspectRatio"] = str(aspect_ratio).strip()
+        if image_size:
+            image_options["imageSize"] = str(image_size).strip().upper()
+        if image_options:
+            generation_config["imageConfig"] = image_options
+        return generation_config
+
+    def _build_top_level_overrides(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        top_level = {}
+        for source_key, target_key in (
+            ("safetySettings", "safetySettings"),
+            ("safety_settings", "safetySettings"),
+            ("systemInstruction", "systemInstruction"),
+            ("system_instruction", "systemInstruction"),
+        ):
+            if source_key in params:
+                top_level[target_key] = params.pop(source_key)
+        return top_level
+
+    def _failure_summary(self, payload: Any) -> str:
+        if not isinstance(payload, dict):
+            return summarize_response_text_for_log(str(payload), max_string_length=500)
+        candidates = payload.get("candidates")
+        if isinstance(candidates, list) and candidates:
+            candidate = candidates[0] if isinstance(candidates[0], dict) else {}
+            finish_reason = candidate.get("finishReason") or candidate.get("finish_reason") or "UNKNOWN"
+            content = candidate.get("content") or {}
+            parts = content.get("parts") if isinstance(content, dict) else []
+            texts = []
+            if isinstance(parts, list):
+                texts = [str(part.get("text", "")).strip() for part in parts if isinstance(part, dict) and part.get("text")]
+            text_suffix = f"；文本响应: {' '.join(texts)[:240]}" if texts else ""
+            return f"finishReason={finish_reason}{text_suffix}"
+        return summarize_payload_json_for_log(payload, max_string_length=500)
+
+    async def _post_json(self, endpoint: str, headers: Dict[str, str], payload: Dict[str, Any]) -> str:
+        timeout_obj = aiohttp.ClientTimeout(total=self.config.timeout)
+        logger.info(f"📤 [Gemini官方通道] 请求路径: {summarize_url_for_log(endpoint)}")
+        logger.info(f"📤 [Gemini官方通道] 请求体摘要: {summarize_payload_json_for_log(payload)}")
+        async with self.session.post(endpoint, json=payload, headers=headers, timeout=timeout_obj) as response:
+            text = await response.text()
+            if response.status >= 400:
+                logger.error("💥 Gemini官方通道 API 返回错误摘要: " + summarize_response_text_for_log(text, max_string_length=500))
+                raise RuntimeError(f"HTTP {response.status}: {extract_error_message(text)}")
+            try:
+                result = json.loads(text)
+            except Exception:
+                raise ValueError("Gemini 官方接口返回结构异常，响应不是 JSON: " + summarize_response_text_for_log(text))
+            image_url = extract_image_url_from_response(result, endpoint)
+            if image_url:
+                return image_url
+            raise ValueError("Gemini 官方接口未返回图片数据: " + self._failure_summary(result))
+
+    async def generate_image(self, prompt: str, **kwargs: Any) -> str:
+        current_key = self.get_current_key()
+        if not current_key:
+            raise ValueError("节点未配置 API Key！")
+
+        ref_images = self.get_reference_images(**kwargs)
+        if len(ref_images) > MAX_REFERENCE_IMAGES:
+            raise ValueError(f"Gemini 官方接口最多支持 {MAX_REFERENCE_IMAGES} 张参考图。")
+
+        internal_keys = {"user_refs", "user_ref", "persona_refs", "persona_ref"}
+        api_kwargs = {key: value for key, value in kwargs.items() if key not in internal_keys}
+        model = self._request_model(api_kwargs)
+        if not model:
+            raise ValueError("Gemini 官方节点未配置模型名！")
+
+        endpoint = self._endpoint(model)
+        headers = {
+            "Content-Type": "application/json",
+            "x-goog-api-key": current_key,
+        }
+
+        parts: List[Dict[str, Any]] = [{"text": str(prompt or "")}]
+        for index, ref_image in enumerate(ref_images, start=1):
+            try:
+                parts.append(await self._inline_image_part(ref_image))
+            except Exception as exc:
+                raise RuntimeError(f"读取第 {index} 张参考图数据失败: {exc}")
+
+        payload: Dict[str, Any] = {
+            "contents": [{"role": "user", "parts": parts}],
+            "generationConfig": self._build_generation_config(api_kwargs),
+        }
+        payload.update(self._build_top_level_overrides(api_kwargs))
+
+        if api_kwargs:
+            ignored = ", ".join(sorted(str(key) for key in api_kwargs))
+            logger.info(f"ℹ️ [Gemini官方通道] 已忽略非 Gemini 官方参数: {ignored}")
+
+        logger.info(f"📝 [Gemini官方通道] 最终发送给 API 的核心提示词:\n{prompt}")
+        return await self._post_json(endpoint, headers, payload)

--- a/providers/gemini_official_impl.py
+++ b/providers/gemini_official_impl.py
@@ -25,7 +25,22 @@ from .base import (
 
 
 MAX_REFERENCE_IMAGES = 14
-ALLOWED_ASPECT_RATIOS = ("1:1", "3:4", "4:3", "9:16", "16:9")
+ALLOWED_ASPECT_RATIOS = (
+    "1:1",
+    "3:4",
+    "4:3",
+    "9:16",
+    "16:9",
+    "2:3",
+    "3:2",
+    "4:5",
+    "5:4",
+    "21:9",
+    "1:4",
+    "4:1",
+    "1:8",
+    "8:1",
+)
 
 
 class GeminiOfficialProvider(BaseProvider):
@@ -52,8 +67,8 @@ class GeminiOfficialProvider(BaseProvider):
     async def _inline_image_part(self, image_path_or_url: str) -> Dict[str, Any]:
         image_bytes = await self._get_image_bytes(image_path_or_url)
         return {
-            "inline_data": {
-                "mime_type": guess_image_content_type(image_path_or_url),
+            "inlineData": {
+                "mimeType": guess_image_content_type(image_path_or_url),
                 "data": base64.b64encode(image_bytes).decode("ascii"),
             }
         }

--- a/tests/test_custom_endpoint.py
+++ b/tests/test_custom_endpoint.py
@@ -219,6 +219,22 @@ class CustomEndpointHelpersTest(unittest.TestCase):
             "data:image/webp;base64," + final,
         )
 
+    def test_rejects_non_image_or_invalid_gemini_inline_data(self):
+        endpoint = "https://generativelanguage.googleapis.com/v1beta/models/gemini:generateContent"
+        text_inline = {
+            "candidates": [
+                {"content": {"parts": [{"inlineData": {"mimeType": "text/plain", "data": _long_b64()}}]}}
+            ]
+        }
+        invalid_image_inline = {
+            "candidates": [
+                {"content": {"parts": [{"inlineData": {"mimeType": "image/png", "data": "not base64!"}}]}}
+            ]
+        }
+
+        self.assertEqual(extract_image_url_from_response(text_inline, endpoint), "")
+        self.assertEqual(extract_image_url_from_response(invalid_image_inline, endpoint), "")
+
     def test_complete_endpoint_validation_rejects_roots(self):
         self.assertTrue(is_complete_endpoint_url("https://api.example.com/v1/images/generations"))
         self.assertTrue(is_complete_endpoint_url("https://ark.cn-beijing.volces.com/api/v3/images/generations"))
@@ -417,6 +433,12 @@ class RuntimeConfigKeyTest(unittest.TestCase):
         app_js = (PLUGIN_DIR / "pages" / "插件配置" / "app.js").read_text(encoding="utf-8")
         self.assertLess(app_js.index('"gemini_official"'), app_js.index('"custom_endpoint"'))
         self.assertIn("GEMINI_OFFICIAL_BASE_URL", app_js)
+        self.assertNotIn("return applyImageProviderDefaults({", app_js)
+
+    def test_tests_directory_is_not_gitignored(self):
+        gitignore = (PLUGIN_DIR / ".gitignore").read_text(encoding="utf-8")
+
+        self.assertNotIn("tests/", gitignore.splitlines())
 
     def test_provider_factory_creates_gemini_provider(self):
         config = ProviderConfig(
@@ -679,6 +701,14 @@ class GeminiOfficialProviderTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(payload["generationConfig"]["imageConfig"]["aspectRatio"], "1:1")
         self.assertNotIn("size", payload)
 
+    async def test_size_mapping_supports_wide_official_aspect_ratios(self):
+        provider, session = self._provider(self._gemini_response())
+
+        await provider.generate_image("wide scene", size="2560x1080")
+
+        payload = session.posts[0]["json"]
+        self.assertEqual(payload["generationConfig"]["imageConfig"]["aspectRatio"], "21:9")
+
     async def test_reference_image_uses_official_inline_data_part(self):
         provider, session = self._provider(self._gemini_response())
         reference = "data:image/jpeg;base64," + _long_b64()
@@ -687,8 +717,8 @@ class GeminiOfficialProviderTest(unittest.IsolatedAsyncioTestCase):
 
         parts = session.posts[0]["json"]["contents"][0]["parts"]
         self.assertEqual(parts[0]["text"], "edit a cat")
-        self.assertEqual(parts[1]["inline_data"]["mime_type"], "image/jpeg")
-        self.assertEqual(parts[1]["inline_data"]["data"], _long_b64())
+        self.assertEqual(parts[1]["inlineData"]["mimeType"], "image/jpeg")
+        self.assertEqual(parts[1]["inlineData"]["data"], _long_b64())
 
     async def test_preserves_full_generate_content_endpoint(self):
         endpoint = "https://generativelanguage.googleapis.com/v1beta/models/custom-image:generateContent"

--- a/tests/test_custom_endpoint.py
+++ b/tests/test_custom_endpoint.py
@@ -1,0 +1,1061 @@
+import ast
+import base64
+import importlib
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+PLUGIN_DIR = Path(__file__).resolve().parents[1]
+PACKAGE_NAME = PLUGIN_DIR.name
+PACKAGE_PARENT = PLUGIN_DIR.parent
+sys.path.insert(0, str(PACKAGE_PARENT))
+
+astrbot_module = types.ModuleType("astrbot")
+astrbot_api_module = types.ModuleType("astrbot.api")
+astrbot_event_module = types.ModuleType("astrbot.api.event")
+astrbot_message_components_module = types.ModuleType("astrbot.api.message_components")
+astrbot_star_module = types.ModuleType("astrbot.api.star")
+quart_module = types.ModuleType("quart")
+
+
+class _Logger:
+    def __init__(self):
+        self.messages = []
+
+    def info(self, *args, **kwargs):
+        self.messages.append(("info", " ".join(str(arg) for arg in args)))
+
+    def warning(self, *args, **kwargs):
+        self.messages.append(("warning", " ".join(str(arg) for arg in args)))
+
+    def error(self, *args, **kwargs):
+        self.messages.append(("error", " ".join(str(arg) for arg in args)))
+
+
+fake_logger = _Logger()
+astrbot_api_module.logger = fake_logger
+astrbot_event_module.AstrMessageEvent = object
+
+
+class _Plain:
+    def __init__(self, text=""):
+        self.text = text
+
+
+class _Video:
+    @classmethod
+    def fromURL(cls, url):
+        return {"type": "video", "url": url}
+
+
+class _Image:
+    @classmethod
+    def fromFileSystem(cls, path):
+        return {"type": "image_file", "path": path}
+
+    @classmethod
+    def fromURL(cls, url):
+        return {"type": "image_url", "url": url}
+
+
+class _Filter:
+    class PermissionType:
+        ADMIN = "admin"
+
+    def command(self, *args, **kwargs):
+        return lambda func: func
+
+    def permission_type(self, *args, **kwargs):
+        return lambda func: func
+
+    def event_message_type(self, *args, **kwargs):
+        return lambda func: func
+
+
+class _Star:
+    def __init__(self, context=None):
+        self.context = context
+
+
+def _identity_decorator(*args, **kwargs):
+    return lambda item: item
+
+
+def _jsonify(*args, **kwargs):
+    return {"args": args, "kwargs": kwargs}
+
+
+async def _send_file(*args, **kwargs):
+    return {"args": args, "kwargs": kwargs}
+
+
+astrbot_message_components_module.Plain = _Plain
+astrbot_message_components_module.Image = _Image
+astrbot_message_components_module.Video = _Video
+astrbot_event_module.filter = _Filter()
+astrbot_event_module.EventMessageType = types.SimpleNamespace(ALL="all")
+astrbot_api_module.llm_tool = _identity_decorator
+astrbot_star_module.Context = object
+astrbot_star_module.Star = _Star
+astrbot_star_module.register = _identity_decorator
+quart_module.jsonify = _jsonify
+quart_module.request = types.SimpleNamespace(get_json=lambda *args, **kwargs: {})
+quart_module.send_file = _send_file
+sys.modules.setdefault("astrbot", astrbot_module)
+sys.modules.setdefault("astrbot.api", astrbot_api_module)
+sys.modules.setdefault("astrbot.api.event", astrbot_event_module)
+sys.modules.setdefault("astrbot.api.message_components", astrbot_message_components_module)
+sys.modules.setdefault("astrbot.api.star", astrbot_star_module)
+sys.modules.setdefault("quart", quart_module)
+
+models_module = importlib.import_module(f"{PACKAGE_NAME}.models")
+base_module = importlib.import_module(f"{PACKAGE_NAME}.providers.base")
+custom_endpoint_module = importlib.import_module(f"{PACKAGE_NAME}.providers.custom_endpoint_impl")
+gemini_official_module = importlib.import_module(f"{PACKAGE_NAME}.providers.gemini_official_impl")
+openai_impl_module = importlib.import_module(f"{PACKAGE_NAME}.providers.openai_impl")
+openai_chat_module = importlib.import_module(f"{PACKAGE_NAME}.providers.openai_chat_impl")
+provider_factory_module = importlib.import_module(f"{PACKAGE_NAME}.providers")
+chain_manager_module = importlib.import_module(f"{PACKAGE_NAME}.core.chain_manager")
+video_manager_module = importlib.import_module(f"{PACKAGE_NAME}.core.video_manager")
+main_module = importlib.import_module(f"{PACKAGE_NAME}.main")
+
+ProviderConfig = models_module.ProviderConfig
+PluginConfig = models_module.PluginConfig
+_normalize_api_type = models_module._normalize_api_type
+ChainRunResult = chain_manager_module.ChainRunResult
+ChainManager = chain_manager_module.ChainManager
+OmniDrawPlugin = main_module.OmniDrawPlugin
+VideoManager = video_manager_module.VideoManager
+extract_error_message = base_module.extract_error_message
+extract_image_url_from_response = base_module.extract_image_url_from_response
+is_complete_endpoint_url = base_module.is_complete_endpoint_url
+summarize_payload_for_log = base_module.summarize_payload_for_log
+summarize_text_for_log = base_module.summarize_text_for_log
+summarize_url_for_log = base_module.summarize_url_for_log
+CustomEndpointProvider = custom_endpoint_module.CustomEndpointProvider
+GeminiOfficialProvider = gemini_official_module.GeminiOfficialProvider
+OpenAIProvider = openai_impl_module.OpenAIProvider
+OpenAIChatProvider = openai_chat_module.OpenAIChatProvider
+
+
+def _long_b64() -> str:
+    return base64.b64encode(b"image-bytes" * 20).decode("ascii")
+
+
+class FakeResponse:
+    def __init__(self, payload, status=200):
+        self.payload = payload
+        self.status = status
+
+    async def text(self):
+        return self.payload if isinstance(self.payload, str) else json.dumps(self.payload)
+
+    async def json(self):
+        if isinstance(self.payload, str):
+            return json.loads(self.payload)
+        return self.payload
+
+
+class FakePost:
+    def __init__(self, response):
+        self.response = response
+
+    async def __aenter__(self):
+        return self.response
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class FakeSession:
+    def __init__(self, response):
+        self.response = response
+        self.posts = []
+        self.gets = []
+
+    def post(self, url, **kwargs):
+        self.posts.append({"url": url, **kwargs})
+        return FakePost(self.response)
+
+    def get(self, url, **kwargs):
+        self.gets.append({"url": url, **kwargs})
+        return FakePost(self.response)
+
+
+class CustomEndpointHelpersTest(unittest.TestCase):
+    def test_custom_api_type_is_preserved(self):
+        self.assertEqual(_normalize_api_type("custom_endpoint", is_video=False), "custom_endpoint")
+        self.assertEqual(_normalize_api_type("自定义", is_video=False), "custom_endpoint")
+
+    def test_gemini_official_api_type_is_preserved(self):
+        self.assertEqual(_normalize_api_type("gemini_official", is_video=False), "gemini_official")
+        self.assertEqual(_normalize_api_type("Gemini", is_video=False), "gemini_official")
+        self.assertEqual(_normalize_api_type("Gemini 官方", is_video=False), "gemini_official")
+
+    def test_extracts_gemini_inline_data_response(self):
+        endpoint = "https://generativelanguage.googleapis.com/v1beta/models/gemini:generateContent"
+        first = base64.b64encode(b"first-image" * 20).decode("ascii")
+        final = base64.b64encode(b"final-image" * 20).decode("ascii")
+        payload = {
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {"text": "draft"},
+                            {"inlineData": {"mimeType": "image/png", "data": first}},
+                            {"inline_data": {"mime_type": "image/webp", "data": final}},
+                        ]
+                    },
+                    "finishReason": "STOP",
+                }
+            ]
+        }
+
+        self.assertEqual(
+            extract_image_url_from_response(payload, endpoint),
+            "data:image/webp;base64," + final,
+        )
+
+    def test_complete_endpoint_validation_rejects_roots(self):
+        self.assertTrue(is_complete_endpoint_url("https://api.example.com/v1/images/generations"))
+        self.assertTrue(is_complete_endpoint_url("https://ark.cn-beijing.volces.com/api/v3/images/generations"))
+        self.assertFalse(is_complete_endpoint_url("https://api.example.com"))
+        self.assertFalse(is_complete_endpoint_url("https://api.example.com/v1"))
+        self.assertFalse(is_complete_endpoint_url("https://api.example.com/api"))
+
+    def test_extracts_common_image_shapes(self):
+        endpoint = "https://api.example.com/v1/images/generations"
+        self.assertEqual(
+            extract_image_url_from_response({"data": [{"url": "https://cdn.example.com/a.png"}]}, endpoint),
+            "https://cdn.example.com/a.png",
+        )
+        self.assertTrue(
+            extract_image_url_from_response({"data": [{"b64_json": _long_b64()}]}, endpoint).startswith(
+                "data:image/png;base64,"
+            )
+        )
+        self.assertEqual(
+            extract_image_url_from_response(
+                {"choices": [{"message": {"content": "![image](https://cdn.example.com/chat.png)"}}]},
+                endpoint,
+            ),
+            "https://cdn.example.com/chat.png",
+        )
+        self.assertEqual(
+            extract_image_url_from_response(
+                {"choices": [{"message": {"content": [{"type": "text", "text": "https://cdn.example.com/list.png"}]}}]},
+                endpoint,
+            ),
+            "https://cdn.example.com/list.png",
+        )
+        self.assertTrue(
+            extract_image_url_from_response({"output": [{"type": "image_generation_call", "result": _long_b64()}]}, endpoint).startswith(
+                "data:image/png;base64,"
+            )
+        )
+        self.assertTrue(
+            extract_image_url_from_response({"image": _long_b64()}, endpoint).startswith("data:image/png;base64,")
+        )
+        self.assertEqual(
+            extract_image_url_from_response({"images": [{"url": "/files/out.png"}]}, endpoint),
+            "https://api.example.com/files/out.png",
+        )
+        self.assertEqual(
+            extract_image_url_from_response({"image": "files/from-image-key.webp"}, endpoint),
+            "https://api.example.com/files/from-image-key.webp",
+        )
+
+    def test_payload_log_summary_redacts_nested_data_urls(self):
+        image_data_url = "data:image/jpeg;base64," + _long_b64()
+        upper_image_data_url = "DATA:Image/PNG;base64," + _long_b64()
+        raw_image = base64.b64encode(b"raw-image" * 40).decode("ascii")
+        payload = {
+            "model": "gpt-image-2",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image_url", "image_url": {"url": image_data_url}},
+                        {"type": "image_url", "image_url": {"url": upper_image_data_url}},
+                        {"type": "text", "text": "x" * 220},
+                    ],
+                }
+            ],
+            "b64_json": raw_image,
+            "image": raw_image,
+            "api_key": "sk-test-should-not-log",
+        }
+
+        summary = summarize_payload_for_log(payload)
+
+        image_summary = summary["messages"][0]["content"][0]["image_url"]["url"]
+        upper_image_summary = summary["messages"][0]["content"][1]["image_url"]["url"]
+        text_summary = summary["messages"][0]["content"][2]["text"]
+        self.assertIn("<image_data_url", image_summary)
+        self.assertIn("<image_data_url", upper_image_summary)
+        self.assertIn("chars=", image_summary)
+        self.assertNotIn(_long_b64()[:40], str(summary))
+        self.assertNotIn(raw_image[:40], str(summary))
+        self.assertEqual(summary["b64_json"], f"<image_base64 chars={len(raw_image)}>")
+        self.assertEqual(summary["image"], f"<image_base64 chars={len(raw_image)}>")
+        self.assertEqual(text_summary, "<text chars=220>")
+        self.assertEqual(summary["api_key"], "<redacted>")
+
+    def test_extract_error_message_sanitizes_echoed_payload(self):
+        raw_image = base64.b64encode(b"raw-image" * 40).decode("ascii")
+        payload = {
+            "error": {
+                "message": {
+                    "api_key": "sk-test-should-not-log",
+                    "image": raw_image,
+                    "text": "x" * 300,
+                }
+            }
+        }
+
+        message = extract_error_message(json.dumps(payload))
+
+        self.assertNotIn("sk-test-should-not-log", message)
+        self.assertNotIn(raw_image[:40], message)
+        self.assertIn("<redacted>", message)
+        self.assertIn("<image_base64", message)
+
+    def test_error_message_sanitizes_base64_in_result_fields(self):
+        raw_image = base64.b64encode(b"result-image" * 40).decode("ascii")
+        payload = {
+            "error": {
+                "message": {
+                    "output": [
+                        {"type": "image_generation_call", "result": raw_image},
+                    ],
+                    "data": raw_image,
+                }
+            }
+        }
+
+        summary = summarize_payload_for_log(payload)
+        message = extract_error_message(json.dumps(payload))
+
+        self.assertNotIn(raw_image[:40], str(summary))
+        self.assertNotIn(raw_image[:40], message)
+        self.assertIn("<image_base64", str(summary))
+        self.assertIn("<image_base64", message)
+
+    def test_plain_text_log_summary_redacts_embedded_secrets_and_data_urls(self):
+        image_data_url = "data:image/png;base64," + _long_b64()
+        text = "API key: AIzaSyExampleSecret123456789 failed for image " + image_data_url + ". prompt: draw a cat"
+
+        summary = summarize_text_for_log(text, max_string_length=500)
+
+        self.assertNotIn("AIzaSyExampleSecret123456789", summary)
+        self.assertNotIn("draw a cat", summary)
+        self.assertNotIn(_long_b64()[:40], summary)
+        self.assertIn("API key=<redacted>", summary)
+        self.assertIn("prompt=<redacted>", summary)
+        self.assertIn("<image_data_url", summary)
+
+    def test_url_summary_redacts_custom_endpoint_query_values(self):
+        endpoint = (
+            "https://api.example.com/v1/images/generations"
+            "?api_key=AIzaSyExampleSecret123456789&token=plain-token&size=1024x1024"
+        )
+
+        summary = summarize_url_for_log(endpoint)
+
+        self.assertIn("https://api.example.com/v1/images/generations", summary)
+        self.assertIn("api_key=<redacted>", summary)
+        self.assertIn("token=<redacted>", summary)
+        self.assertIn("size=<redacted>", summary)
+        self.assertNotIn("AIzaSyExampleSecret123456789", summary)
+        self.assertNotIn("plain-token", summary)
+        self.assertNotIn("1024x1024", summary)
+
+
+class GenerationMetadataConfigTest(unittest.TestCase):
+    def test_generation_metadata_toggles_default_to_hidden(self):
+        config = PluginConfig.from_dict({}, str(PLUGIN_DIR))
+
+        self.assertFalse(config.show_generation_time)
+        self.assertFalse(config.show_request_model)
+
+    def test_generation_metadata_toggles_are_independent(self):
+        config = PluginConfig.from_dict(
+            {
+                "show_generation_time": True,
+                "show_request_model": False,
+            },
+            str(PLUGIN_DIR),
+        )
+
+        self.assertTrue(config.show_generation_time)
+        self.assertFalse(config.show_request_model)
+
+
+class RuntimeConfigKeyTest(unittest.TestCase):
+    def test_generation_metadata_keys_are_preserved_by_runtime_config_cleaner(self):
+        tree = ast.parse((PLUGIN_DIR / "main.py").read_text(encoding="utf-8"))
+        config_keys = set()
+        for node in tree.body:
+            if isinstance(node, ast.Assign) and any(
+                isinstance(target, ast.Name) and target.id == "CONFIG_KEYS"
+                for target in node.targets
+            ):
+                config_keys = set(ast.literal_eval(node.value))
+                break
+
+        self.assertIn("show_generation_time", config_keys)
+        self.assertIn("show_request_model", config_keys)
+
+    def test_schema_and_pages_offer_gemini_before_custom(self):
+        schema = json.loads((PLUGIN_DIR / "_conf_schema.json").read_text(encoding="utf-8"))
+        options = schema["providers"]["templates"]["image_provider"]["items"]["api_type"]["options"]
+        self.assertLess(options.index("gemini_official"), options.index("custom_endpoint"))
+
+        app_js = (PLUGIN_DIR / "pages" / "插件配置" / "app.js").read_text(encoding="utf-8")
+        self.assertLess(app_js.index('"gemini_official"'), app_js.index('"custom_endpoint"'))
+        self.assertIn("GEMINI_OFFICIAL_BASE_URL", app_js)
+
+    def test_provider_factory_creates_gemini_provider(self):
+        config = ProviderConfig(
+            id="gemini_node",
+            api_type="gemini_official",
+            base_url="",
+            api_keys=["test-key"],
+            model="gemini-3.1-flash-image-preview",
+            timeout=120.0,
+        )
+
+        self.assertIsInstance(provider_factory_module.create_provider(config, session=object()), GeminiOfficialProvider)
+
+
+class ImageSuccessComponentsTest(unittest.TestCase):
+    def _plugin(self, show_time=True, show_model=True):
+        plugin = object.__new__(OmniDrawPlugin)
+        plugin.plugin_config = types.SimpleNamespace(
+            show_generation_time=show_time,
+            show_request_model=show_model,
+        )
+        plugin._create_image_component = lambda url: {"type": "image", "url": url}
+        return plugin
+
+    def test_image_success_components_show_metadata_before_image(self):
+        plugin = self._plugin(show_time=True, show_model=True)
+        result = ChainRunResult(
+            image_url="https://cdn.example.com/out.png",
+            provider_id="node_1",
+            model="override-model",
+            elapsed_seconds=1.2,
+        )
+
+        components = plugin._build_image_success_components(result, elapsed_seconds=3.4)
+
+        self.assertEqual(len(components), 2)
+        self.assertIn("生图耗时：3.4s", components[0].text)
+        self.assertIn("请求模型：override-model", components[0].text)
+        self.assertEqual(components[1], {"type": "image", "url": "https://cdn.example.com/out.png"})
+
+    def test_image_success_components_can_hide_metadata_for_llm_tools(self):
+        plugin = self._plugin(show_time=True, show_model=True)
+        result = ChainRunResult(
+            image_url="https://cdn.example.com/out.png",
+            provider_id="node_1",
+            model="override-model",
+            elapsed_seconds=1.2,
+        )
+
+        components = plugin._build_image_success_components(result, include_metadata=False)
+
+        self.assertEqual(components, [{"type": "image", "url": "https://cdn.example.com/out.png"}])
+
+    def test_image_success_components_allow_independent_toggles(self):
+        result = ChainRunResult(
+            image_url="https://cdn.example.com/out.png",
+            provider_id="node_1",
+            model="actual-model",
+            elapsed_seconds=1.2,
+        )
+
+        time_only = self._plugin(show_time=True, show_model=False)._build_image_success_components(result)
+        model_only = self._plugin(show_time=False, show_model=True)._build_image_success_components(result)
+        hidden = self._plugin(show_time=False, show_model=False)._build_image_success_components(result)
+
+        self.assertIn("生图耗时", time_only[0].text)
+        self.assertNotIn("请求模型", time_only[0].text)
+        self.assertNotIn("生图耗时", model_only[0].text)
+        self.assertIn("请求模型：actual-model", model_only[0].text)
+        self.assertEqual(hidden, [{"type": "image", "url": "https://cdn.example.com/out.png"}])
+
+
+class ChainManagerMetadataTest(unittest.IsolatedAsyncioTestCase):
+    async def test_chain_result_uses_actual_successful_provider_metadata(self):
+        config = PluginConfig.from_dict(
+            {
+                "providers": [
+                    {
+                        "id": "primary",
+                        "api_type": "openai_image",
+                        "base_url": "https://api.example.com/v1",
+                        "api_keys": "key-1",
+                        "model": "primary-model",
+                    },
+                    {
+                        "id": "backup",
+                        "api_type": "openai_image",
+                        "base_url": "https://api.example.com/v1",
+                        "api_keys": "key-2",
+                        "model": "backup-model",
+                    },
+                ],
+                "router_config": {"chain_text2img": "primary,backup"},
+            },
+            str(PLUGIN_DIR),
+        )
+        calls = []
+
+        class FakeProvider:
+            def __init__(self, provider_config):
+                self.provider_config = provider_config
+
+            async def generate_image(self, prompt, **kwargs):
+                calls.append((self.provider_config.id, prompt, kwargs))
+                if self.provider_config.id == "primary":
+                    raise RuntimeError("primary failed")
+                return "https://cdn.example.com/out.png"
+
+        original_create_provider = chain_manager_module.create_provider
+        chain_manager_module.create_provider = lambda provider_config, session: FakeProvider(provider_config)
+        try:
+            manager = ChainManager(config, session=object())
+            result = await manager.run_chain_with_metadata(
+                "text2img",
+                "draw a cat",
+                size="1024x1024",
+                model="override-model",
+            )
+
+            self.assertEqual(result.image_url, "https://cdn.example.com/out.png")
+            self.assertEqual(result.provider_id, "backup")
+            self.assertEqual(result.model, "override-model")
+            self.assertGreaterEqual(result.elapsed_seconds, 0)
+            self.assertEqual([call[0] for call in calls], ["primary", "backup"])
+            self.assertEqual(await manager.run_chain("text2img", "draw a cat"), "https://cdn.example.com/out.png")
+        finally:
+            chain_manager_module.create_provider = original_create_provider
+
+    async def test_gemini_chain_allows_default_base_url(self):
+        config = PluginConfig.from_dict(
+            {
+                "providers": [
+                    {
+                        "id": "gemini",
+                        "api_type": "gemini_official",
+                        "base_url": "",
+                        "api_keys": "key-1",
+                        "model": "",
+                    }
+                ],
+                "router_config": {"chain_text2img": "gemini"},
+            },
+            str(PLUGIN_DIR),
+        )
+        calls = []
+
+        class FakeProvider:
+            async def generate_image(self, prompt, **kwargs):
+                calls.append((prompt, kwargs))
+                return "data:image/png;base64," + _long_b64()
+
+        original_create_provider = chain_manager_module.create_provider
+        chain_manager_module.create_provider = lambda provider_config, session: FakeProvider()
+        try:
+            manager = ChainManager(config, session=object())
+            result = await manager.run_chain_with_metadata("text2img", "draw a cat")
+
+            self.assertTrue(result.image_url.startswith("data:image/png;base64,"))
+            self.assertEqual(result.provider_id, "gemini")
+            self.assertEqual(result.model, "gemini-3.1-flash-image-preview")
+            self.assertEqual(calls, [("draw a cat", {})])
+        finally:
+            chain_manager_module.create_provider = original_create_provider
+
+
+class VideoSuccessMetadataTest(unittest.TestCase):
+    def test_success_text_respects_metadata_toggles(self):
+        config = PluginConfig.from_dict(
+            {"show_generation_time": True, "show_request_model": False},
+            str(PLUGIN_DIR),
+        )
+        text = VideoManager(config)._build_success_text(65.2, "veo-3")
+
+        self.assertIn("生成耗时", text)
+        self.assertIn("65.2s", text)
+        self.assertNotIn("请求模型", text)
+        self.assertNotIn("veo-3", text)
+
+        config = PluginConfig.from_dict(
+            {"show_generation_time": False, "show_request_model": True},
+            str(PLUGIN_DIR),
+        )
+        manager = VideoManager(config)
+        provider = ProviderConfig(
+            id="video_node",
+            api_type="async_task",
+            base_url="https://api.example.com/v1",
+            api_keys=["key"],
+            model="veo-3",
+            timeout=300.0,
+        )
+        text = manager._build_success_text(
+            65.2,
+            manager._effective_request_model(provider, {"model": "video-override"}),
+        )
+
+        self.assertNotIn("生成耗时", text)
+        self.assertIn("请求模型：video-override", text)
+
+    def test_success_text_can_hide_metadata_for_llm_tools(self):
+        config = PluginConfig.from_dict(
+            {"show_generation_time": True, "show_request_model": True},
+            str(PLUGIN_DIR),
+        )
+        text = VideoManager(config)._build_success_text(65.2, "veo-3", include_metadata=False)
+
+        self.assertNotIn("生成耗时", text)
+        self.assertNotIn("请求模型", text)
+        self.assertNotIn("veo-3", text)
+
+
+class GeminiOfficialProviderTest(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        fake_logger.messages.clear()
+
+    def _provider(self, response_payload, base_url="", status=200):
+        config = ProviderConfig(
+            id="gemini_node",
+            api_type="gemini_official",
+            base_url=base_url,
+            api_keys=["gemini-key"],
+            model="gemini-3.1-flash-image-preview",
+            timeout=120.0,
+        )
+        session = FakeSession(FakeResponse(response_payload, status=status))
+        return GeminiOfficialProvider(config, session), session
+
+    def _gemini_response(self, mime_type="image/png"):
+        return {
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {"text": "created"},
+                            {"inlineData": {"mimeType": mime_type, "data": _long_b64()}},
+                        ]
+                    },
+                    "finishReason": "STOP",
+                }
+            ]
+        }
+
+    async def test_posts_generate_content_to_default_google_endpoint(self):
+        provider, session = self._provider(self._gemini_response("image/webp"))
+
+        result = await provider.generate_image("draw a cat", size="1024x1024")
+
+        self.assertTrue(result.startswith("data:image/webp;base64,"))
+        self.assertEqual(
+            session.posts[0]["url"],
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-image-preview:generateContent",
+        )
+        headers = session.posts[0]["headers"]
+        self.assertEqual(headers["x-goog-api-key"], "gemini-key")
+        self.assertNotIn("Authorization", headers)
+        payload = session.posts[0]["json"]
+        self.assertEqual(payload["contents"][0]["role"], "user")
+        self.assertEqual(payload["contents"][0]["parts"][0]["text"], "draw a cat")
+        self.assertEqual(payload["generationConfig"]["responseModalities"], ["TEXT", "IMAGE"])
+        self.assertEqual(payload["generationConfig"]["imageConfig"]["aspectRatio"], "1:1")
+        self.assertNotIn("size", payload)
+
+    async def test_reference_image_uses_official_inline_data_part(self):
+        provider, session = self._provider(self._gemini_response())
+        reference = "data:image/jpeg;base64," + _long_b64()
+
+        await provider.generate_image("edit a cat", user_refs=[reference])
+
+        parts = session.posts[0]["json"]["contents"][0]["parts"]
+        self.assertEqual(parts[0]["text"], "edit a cat")
+        self.assertEqual(parts[1]["inline_data"]["mime_type"], "image/jpeg")
+        self.assertEqual(parts[1]["inline_data"]["data"], _long_b64())
+
+    async def test_preserves_full_generate_content_endpoint(self):
+        endpoint = "https://generativelanguage.googleapis.com/v1beta/models/custom-image:generateContent"
+        provider, session = self._provider(self._gemini_response(), base_url=endpoint)
+
+        await provider.generate_image("draw a cat")
+
+        self.assertEqual(session.posts[0]["url"], endpoint)
+
+    async def test_text_only_gemini_response_is_reported_as_missing_image(self):
+        provider, _ = self._provider(
+            {
+                "candidates": [
+                    {
+                        "content": {"parts": [{"text": "I cannot create that image."}]},
+                        "finishReason": "SAFETY",
+                    }
+                ]
+            }
+        )
+
+        with self.assertRaisesRegex(ValueError, "未返回图片数据"):
+            await provider.generate_image("draw a cat")
+
+
+class CustomEndpointProviderTest(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        fake_logger.messages.clear()
+
+    def _provider(self, endpoint, response_payload, provider_cls=CustomEndpointProvider, status=200):
+        if provider_cls is CustomEndpointProvider:
+            api_type = "custom_endpoint"
+        elif provider_cls is GeminiOfficialProvider:
+            api_type = "gemini_official"
+        elif provider_cls is OpenAIChatProvider:
+            api_type = "openai_chat"
+        else:
+            api_type = "openai_image"
+        config = ProviderConfig(
+            id="custom_node",
+            api_type=api_type,
+            base_url=endpoint,
+            api_keys=["test-key"],
+            model="image-model",
+            timeout=30.0,
+        )
+        session = FakeSession(FakeResponse(response_payload, status=status))
+        return provider_cls(config, session), session
+
+    def _log_text(self):
+        return "\n".join(message for _, message in fake_logger.messages)
+
+    def _prompt_log_text(self):
+        return "\n".join(message for _, message in fake_logger.messages if "核心提示词" in message)
+
+    def _request_summary_log_text(self):
+        return "\n".join(
+            message
+            for _, message in fake_logger.messages
+            if "请求体摘要" in message or "高级参数" in message or "透传摘要" in message
+        )
+
+    def _non_prompt_log_text(self):
+        return "\n".join(message for _, message in fake_logger.messages if "核心提示词" not in message)
+
+    async def test_posts_exact_image_endpoint(self):
+        endpoint = "https://api.example.com/v1/images/generations"
+        provider, session = self._provider(endpoint, {"data": [{"url": "https://cdn.example.com/out.png"}]})
+
+        result = await provider.generate_image("draw a cat", size="1024x1024")
+
+        self.assertEqual(result, "https://cdn.example.com/out.png")
+        self.assertEqual(session.posts[0]["url"], endpoint)
+        self.assertEqual(session.posts[0]["json"]["prompt"], "draw a cat")
+        self.assertEqual(session.posts[0]["json"]["size"], "1024x1024")
+
+    async def test_custom_image_payload_uses_siliconflow_reference_fields(self):
+        endpoint = "https://api.example.com/v1/images/generations"
+        provider, session = self._provider(endpoint, {"images": [{"url": "https://cdn.example.com/out.png"}]})
+        ref = "data:image/png;base64," + _long_b64()
+        ref2 = "data:image/png;base64," + base64.b64encode(b"ref-2" * 30).decode("ascii")
+        ref3 = "data:image/png;base64," + base64.b64encode(b"ref-3" * 30).decode("ascii")
+
+        await provider.generate_image("edit a cat", user_refs=[ref, ref2, ref3])
+
+        self.assertEqual(session.posts[0]["url"], endpoint)
+        self.assertEqual(session.posts[0]["json"]["image"], ref)
+        self.assertEqual(session.posts[0]["json"]["image2"], ref2)
+        self.assertEqual(session.posts[0]["json"]["image3"], ref3)
+        self.assertNotIn("images", session.posts[0]["json"])
+
+    async def test_preserves_exact_custom_endpoint_url(self):
+        endpoint = "https://api.example.com/v1/images/generations/"
+        provider, session = self._provider(endpoint, {"data": [{"url": "https://cdn.example.com/out.png"}]})
+
+        await provider.generate_image("draw a cat")
+
+        self.assertEqual(session.posts[0]["url"], endpoint)
+
+    async def test_rejects_edits_endpoint_without_reference_image(self):
+        endpoint = "https://api.example.com/v1/images/edits"
+        provider, session = self._provider(endpoint, {"data": [{"url": "unused"}]})
+
+        with self.assertRaisesRegex(ValueError, "至少一张参考图"):
+            await provider.generate_image("edit a cat")
+
+        self.assertEqual(session.posts, [])
+
+    async def test_edits_endpoint_uses_multipart_image_array_for_multiple_references(self):
+        endpoint = "https://api.example.com/v1/images/edits"
+        provider, session = self._provider(endpoint, {"data": [{"url": "https://cdn.example.com/out.png"}]})
+        ref = "data:image/png;base64," + _long_b64()
+        ref2 = "data:image/png;base64," + base64.b64encode(b"ref-2" * 30).decode("ascii")
+
+        await provider.generate_image("edit a cat", user_refs=[ref, ref2])
+
+        self.assertEqual(session.posts[0]["url"], endpoint)
+        form = session.posts[0]["data"]
+        image_field_names = [
+            field[0]["name"]
+            for field in getattr(form, "_fields", [])
+            if field and field[0].get("name", "").startswith("image")
+        ]
+        self.assertEqual(image_field_names, ["image[]", "image[]"])
+
+    async def test_posts_exact_chat_endpoint(self):
+        endpoint = "https://api.example.com/v1/chat/completions"
+        provider, session = self._provider(
+            endpoint,
+            {"choices": [{"message": {"content": "https://cdn.example.com/chat-out.png"}}]},
+        )
+
+        result = await provider.generate_image("draw a cat")
+
+        self.assertEqual(result, "https://cdn.example.com/chat-out.png")
+        self.assertEqual(session.posts[0]["url"], endpoint)
+        self.assertIn("messages", session.posts[0]["json"])
+
+    async def test_posts_exact_responses_endpoint(self):
+        endpoint = "https://api.example.com/v1/responses"
+        provider, session = self._provider(
+            endpoint,
+            {"output": [{"type": "image_generation_call", "result": _long_b64()}]},
+        )
+
+        result = await provider.generate_image("draw a cat")
+
+        self.assertTrue(result.startswith("data:image/png;base64,"))
+        self.assertEqual(session.posts[0]["url"], endpoint)
+        self.assertIn("tools", session.posts[0]["json"])
+
+    async def test_rejects_incomplete_custom_endpoint(self):
+        provider, session = self._provider("https://api.example.com/v1", {"data": [{"url": "unused"}]})
+
+        with self.assertRaisesRegex(ValueError, "完整请求路径"):
+            await provider.generate_image("draw a cat")
+
+        self.assertEqual(session.posts, [])
+
+    async def test_local_reference_missing_does_not_post(self):
+        endpoint = "https://api.example.com/v1/images/generations"
+        provider, session = self._provider(endpoint, {"data": [{"url": "unused"}]})
+
+        with self.assertRaisesRegex(RuntimeError, "本地参考图不存在"):
+            await provider.generate_image("edit a cat", user_refs=["C:/definitely/missing.png"])
+
+        self.assertEqual(session.posts, [])
+
+
+    async def test_provider_logs_are_summarized_without_mutating_json_payloads(self):
+        raw_b64 = base64.b64encode(b"provider-raw-image" * 35).decode("ascii")
+        ref_data_url = "data:image/png;base64," + raw_b64
+        secret = "sk-provider-secret-should-not-log"
+        long_prompt = "draw " + ("very detailed " * 30) + "PROMPT_TAIL_SHOULD_NOT_LOG"
+
+        cases = [
+            (
+                CustomEndpointProvider,
+                "https://api.example.com/v1/images/generations",
+                {"data": [{"url": "https://cdn.example.com/custom.png"}]},
+                {"user_refs": [ref_data_url], "api_key": secret, "b64_json": raw_b64},
+            ),
+            (
+                OpenAIProvider,
+                "https://api.example.com/v1",
+                {"data": [{"url": "https://cdn.example.com/openai.png"}]},
+                {"api_key": secret, "b64_json": raw_b64},
+            ),
+            (
+                OpenAIChatProvider,
+                "https://api.example.com/v1",
+                {"choices": [{"message": {"content": "https://cdn.example.com/chat.png"}}]},
+                {"api_key": secret, "b64_json": raw_b64},
+            ),
+        ]
+
+        for provider_cls, endpoint, response_payload, kwargs in cases:
+            with self.subTest(provider_cls=provider_cls.__name__):
+                fake_logger.messages.clear()
+                provider, session = self._provider(endpoint, response_payload, provider_cls=provider_cls)
+
+                await provider.generate_image(long_prompt, **kwargs)
+
+                sent_payload = session.posts[0]["json"]
+                if provider_cls is CustomEndpointProvider:
+                    self.assertEqual(sent_payload["prompt"], long_prompt)
+                    self.assertEqual(sent_payload["image"], ref_data_url)
+                elif provider_cls is OpenAIProvider:
+                    self.assertEqual(sent_payload["prompt"], long_prompt)
+                else:
+                    self.assertIn(long_prompt, sent_payload["messages"][0]["content"][0]["text"])
+                self.assertEqual(sent_payload["api_key"], secret)
+                self.assertEqual(sent_payload["b64_json"], raw_b64)
+
+                logs = self._log_text()
+                self.assertNotIn(secret, logs)
+                self.assertNotIn(raw_b64[:40], logs)
+                self.assertIn(long_prompt, self._prompt_log_text())
+                self.assertIn("PROMPT_TAIL_SHOULD_NOT_LOG", self._prompt_log_text())
+                self.assertIn("<redacted>", logs)
+                self.assertIn("<image_base64", logs)
+                summary_logs = self._request_summary_log_text()
+                self.assertNotIn(long_prompt, summary_logs)
+                self.assertNotIn("PROMPT_TAIL_SHOULD_NOT_LOG", summary_logs)
+                if provider_cls is not OpenAIChatProvider:
+                    self.assertIn("<prompt chars=", summary_logs)
+
+    async def test_short_prompts_and_custom_endpoint_queries_do_not_leak_to_logs(self):
+        short_prompt = "draw a cat"
+        query_secret = "AIzaSyQuerySecret123456789"
+        cases = [
+            (
+                CustomEndpointProvider,
+                "https://api.example.com/v1/images/generations?api_key=" + query_secret + "&size=1024x1024",
+                {"data": [{"url": "https://cdn.example.com/custom.png"}]},
+                lambda payload: payload["prompt"],
+            ),
+            (
+                CustomEndpointProvider,
+                "https://api.example.com/v1/chat/completions",
+                {"choices": [{"message": {"content": "https://cdn.example.com/custom-chat.png"}}]},
+                lambda payload: payload["messages"][0]["content"][0]["text"],
+            ),
+            (
+                CustomEndpointProvider,
+                "https://api.example.com/v1/responses",
+                {"output": [{"type": "image_generation_call", "result": _long_b64()}]},
+                lambda payload: payload["input"],
+            ),
+            (
+                OpenAIProvider,
+                "https://api.example.com/v1",
+                {"data": [{"url": "https://cdn.example.com/openai.png"}]},
+                lambda payload: payload["prompt"],
+            ),
+            (
+                OpenAIChatProvider,
+                "https://api.example.com/v1",
+                {"choices": [{"message": {"content": "https://cdn.example.com/chat.png"}}]},
+                lambda payload: payload["messages"][0]["content"][0]["text"],
+            ),
+        ]
+
+        for provider_cls, endpoint, response_payload, prompt_getter in cases:
+            with self.subTest(provider_cls=provider_cls.__name__, endpoint=endpoint):
+                fake_logger.messages.clear()
+                provider, session = self._provider(endpoint, response_payload, provider_cls=provider_cls)
+
+                await provider.generate_image(short_prompt)
+
+                self.assertIn(short_prompt, prompt_getter(session.posts[0]["json"]))
+                if provider_cls is CustomEndpointProvider:
+                    self.assertEqual(session.posts[0]["url"], endpoint)
+                logs = self._log_text()
+                self.assertIn(short_prompt, self._prompt_log_text())
+                self.assertNotIn(short_prompt, self._request_summary_log_text())
+                self.assertNotIn(query_secret, logs)
+                self.assertNotIn("1024x1024", logs)
+                if provider_cls is not OpenAIChatProvider:
+                    summary_logs = self._request_summary_log_text()
+                    self.assertTrue(
+                        "<prompt chars=" in summary_logs
+                        or "<text chars=" in summary_logs
+                        or "<input chars=" in summary_logs
+                    )
+                if query_secret in endpoint:
+                    self.assertIn("api_key=<redacted>", logs)
+
+    async def test_provider_error_logs_and_exceptions_are_sanitized(self):
+        raw_b64 = base64.b64encode(b"provider-error-image" * 40).decode("ascii")
+        secret = "sk-error-secret-should-not-log"
+        long_detail = ("echoed error detail " * 40) + "ERROR_TAIL_SHOULD_NOT_LOG"
+        error_payload = {
+            "error": {
+                "message": {
+                    "api_key": secret,
+                    "image": raw_b64,
+                    "detail": long_detail,
+                }
+            }
+        }
+
+        cases = [
+            (CustomEndpointProvider, "https://api.example.com/v1/images/generations"),
+            (OpenAIProvider, "https://api.example.com/v1"),
+            (OpenAIChatProvider, "https://api.example.com/v1"),
+        ]
+
+        for provider_cls, endpoint in cases:
+            with self.subTest(provider_cls=provider_cls.__name__):
+                fake_logger.messages.clear()
+                provider, _ = self._provider(endpoint, error_payload, provider_cls=provider_cls, status=400)
+
+                with self.assertRaises(RuntimeError) as raised:
+                    await provider.generate_image("draw a cat")
+
+                combined = str(raised.exception) + "\n" + self._log_text()
+                self.assertNotIn(secret, combined)
+                self.assertNotIn(raw_b64[:40], combined)
+                self.assertNotIn("ERROR_TAIL_SHOULD_NOT_LOG", combined)
+                self.assertIn("<redacted>", combined)
+                self.assertIn("<image_base64", combined)
+
+    async def test_short_error_text_does_not_echo_prompt_or_non_openai_key(self):
+        query_secret = "AIzaSyErrorSecret123456789"
+        error_payload = {"error": {"message": "Invalid API key: " + query_secret + " for prompt: draw a cat"}}
+        cases = [
+            (CustomEndpointProvider, "https://api.example.com/v1/images/generations"),
+            (OpenAIProvider, "https://api.example.com/v1"),
+            (OpenAIChatProvider, "https://api.example.com/v1"),
+        ]
+
+        for provider_cls, endpoint in cases:
+            with self.subTest(provider_cls=provider_cls.__name__):
+                fake_logger.messages.clear()
+                provider, _ = self._provider(endpoint, error_payload, provider_cls=provider_cls, status=400)
+
+                with self.assertRaises(RuntimeError) as raised:
+                    await provider.generate_image("draw a cat")
+
+                combined = str(raised.exception) + "\n" + self._non_prompt_log_text()
+                self.assertNotIn(query_secret, combined)
+                self.assertNotIn("draw a cat", combined)
+                self.assertIn("API key=<redacted>", combined)
+                self.assertIn("prompt=<redacted>", combined)
+                self.assertIn("draw a cat", self._prompt_log_text())
+
+    async def test_unexpected_success_response_exception_is_summarized(self):
+        raw_b64 = base64.b64encode(b"unexpected-success-image" * 35).decode("ascii")
+        payload = {
+            "error": {
+                "api_key": "sk-success-secret-should-not-log",
+                "image": raw_b64,
+                "detail": "x" * 700,
+            }
+        }
+        provider, _ = self._provider("https://api.example.com/v1", payload, provider_cls=OpenAIProvider)
+
+        with self.assertRaises(ValueError) as raised:
+            await provider.generate_image("draw a cat")
+
+        message = str(raised.exception)
+        self.assertNotIn("sk-success-secret-should-not-log", message)
+        self.assertNotIn(raw_b64[:40], message)
+        self.assertIn("<redacted>", message)
+        self.assertIn("<image_base64", message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a dedicated `gemini_official` image provider that calls Google Gemini `generateContent` with `x-goog-api-key`
- add Gemini before Custom in the native schema and Pages UI, with Google default base URL/model defaults
- parse Gemini `candidates[].content.parts[].inlineData` image responses and cover the flow with regression tests

## Validation
- `python -m unittest discover -s tests` -> 40 tests OK
- `python -m compileall -q .` -> OK
- `python -m json.tool _conf_schema.json > $null` -> OK
- `git diff --cached --check` -> OK before commit

## Notes
- The working tree still has pre-existing unstaged line-ending-only edits in `core/prompt_optimizer.py` and `utils.py`; they are not included in this PR.
- Gemini request shape was aligned with Google docs for image generation: `generateContent`, `generationConfig.responseModalities`, optional `generationConfig.imageConfig`, and inline image parts.