### PR TITLE
fix: 智能解析流式和非流式响应，修复副脑在某些端点上的解析失败问题

### DIFF
--- a/core/prompt_optimizer.py
+++ b/core/prompt_optimizer.py
@@ -12,6 +12,50 @@ class PromptOptimizer:
     def __init__(self, config: PluginConfig):
         self.config = config
 
+    async def _read_chat_response(self, resp: aiohttp.ClientResponse) -> dict:
+        """智能解析聊天完成响应，自动处理流式和非流式响应。
+
+        当响应为 text/event-stream 时，解析 SSE 流并重组消息；
+        否则直接解析为 JSON。这样即使服务器忽略 stream=false 参数
+        强制返回流式响应，也能正常工作。
+        """
+        # 先读取文本内容（这样可以多次尝试解析）
+        text_content = await resp.text()
+
+        # 首先尝试 JSON 解析（无论 Content-Type 是什么）
+        # 因为有些服务器会错误地设置 Content-Type 为 text/event-stream 但返回普通 JSON
+        try:
+            return json.loads(text_content)
+        except Exception:
+            # 如果 JSON 解析失败，尝试作为 SSE 流解析
+            pass
+
+        # 解析 SSE 流
+        content_parts = []
+        for line in text_content.splitlines():
+            line = line.strip()
+            if not line.startswith("data:"):
+                continue
+            data_line = line[5:].strip()
+            if not data_line or data_line == "[DONE]":
+                continue
+            try:
+                chunk = json.loads(data_line)
+            except Exception:
+                continue
+            for choice in chunk.get("choices", []):
+                delta = choice.get("delta", {})
+                message = choice.get("message", {})
+                content = delta.get("content") or message.get("content")
+                if content:
+                    content_parts.append(content)
+
+        if content_parts:
+            return {"choices": [{"message": {"content": "".join(content_parts)}}]}
+
+        # 如果 SSE 解析也失败了，返回空响应（让上层处理）
+        return {"choices": [{"message": {"content": ""}}]}
+
     async def optimize(self, raw_action: str, count: int = 1, session: Optional[aiohttp.ClientSession] = None) -> list:
         if not getattr(self.config, "enable_optimizer", True):
             return [raw_action] * count
@@ -170,7 +214,7 @@ OUTPUT FORMAT:
 
                 async with session_obj.post(endpoint, headers=headers, json=payload, timeout=timeout_val) as resp:
                     resp.raise_for_status()
-                    data = await resp.json()
+                    data = await self._read_chat_response(resp)
 
                     if "choices" in data and len(data["choices"]) > 0:
                         raw_content = data["choices"][0]["message"]["content"].strip()


### PR DESCRIPTION
修复副脑优化器在某些 OpenAI 兼容端点上无法正常工作的问题。

问题描述：
部分 OpenAI 兼容端点（如 Grok API）会在响应头中设置 Content-Type 为 text/event-stream，但实际返回的是标准 JSON 格式而非 SSE 流。原有实现直接调用 resp.json() 解析，导致这类端点的响应无法被正确解析，副脑功能失效。

解决方案：
添加 _read_chat_response 方法，实现智能响应解析：
1. 先读取完整响应文本
2. 优先尝试 JSON 解析（无论 Content-Type 是什么）
3. JSON 解析失败时自动降级到 SSE 流式解析
4. 兼容真正的流式响应和错误设置 Content-Type 的 JSON 响应

改动内容：
- 新增 _read_chat_response 方法处理响应解析逻辑
- 替换原有的 resp.json() 调用为 _read_chat_response()
- 不强制设置 stream=false，保持请求灵活性

测试：
已在 Grok API 端点上验证，副脑优化功能恢复正常。

相关 PR：
基于 #39 的思路进行改进，不强制非流式传输，而是在解析层面提供容错。