### PR TITLE
fix: multiple reference image input

### DIFF
--- a/providers/openai_impl.py
+++ b/providers/openai_impl.py
@@ -71,7 +71,7 @@ class OpenAIProvider(BaseProvider):
                 except Exception as e:
                     raise RuntimeError(f"读取第 {idx} 张参考图数据失败: {e}")
                 data.add_field(
-                    "image",
+                    "image[]",
                     image_bytes,
                     filename=f"reference_{idx}.png",
                     content_type=self._content_type(ref_image),


### PR DESCRIPTION

## 修复：多图 edits 的 FormData 字段名

**问题：** `/v1/images/edits` 多参考图时，FormData 使用重复的 `image` 字段名，OpenAI 兼容 API 会拒绝并返回：

```
Duplicate parameter: 'image'. ...use the array syntax instead e.g. 'image[]=<value>'.
```

**改动：** 将 `data.add_field("image", ...)` 改为 `data.add_field("image[]", ...)`，符合 OpenAI 官方 multipart 数组传参规范。

**验证：** `gpt-image-2` 双图参考融合生图已通过测试。